### PR TITLE
fix breadcrumbs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,1 +1,59 @@
-introduction/_index.md
+---
+title: libp2p Documentation 
+weight: 1
+---
+
+Welcome to the libp2p documentation portal! Whether you’re just learning how to build peer-to-peer systems with libp2p, want to dive into peer-to-peer concepts and solutions, or are looking for detailed reference information, this is the place to start.
+
+## Overview
+
+Head over to [What is libp2p?](/introduction/what-is-libp2p/) for an introduction to the basics of libp2p and an overview of the problems it addresses.
+
+
+## Tutorials
+
+If you want to dive in, check out our collection of [tutorials](/tutorials/), which will help guide you through your explorations of libp2p.
+
+## Examples
+
+If you want to get a feel for what's possible with libp2p, or just want to see some idiomatic usage, check out the [examples](/examples/). Each libp2p implementation maintains a set of working example projects that can illustrate key concepts and use cases.
+
+## Reference
+
+### Specifications & Planning
+
+While libp2p has several implementations, it is fundamentally a set of protocols for peer identity, discover, routing, transport and more.
+
+See the [specifications section](/reference/specs/) for details.
+
+### Implementations
+
+At the core of libp2p is a set of [specifications](/reference/specs/), which together form the definition for what libp2p is in the abstract and what makes a "correct" libp2p implementation. Today, implementations of libp2p exist in several languages, with varying degrees of completeness. The most complete implementations are in [Go](/reference/go/) and [JavaScript](/reference/js/), with [rust](https://github.com/libp2p/rust-libp2p) maturing rapidly.
+
+In addition to the implementations above, the libp2p community is actively working on implementations in [python](https://github.com/libp2p/py-libp2p) and [the JVM via Kotlin](https://github.com/web3j/libp2p). Please check the project pages for each implementation to see its status and current state of completeness.
+
+
+## Community
+
+Get in touch with other members of the libp2p community who are building tools and applications with libp2p! You can ask questions, discuss new ideas, or get support for problems at https://discuss.ipfs.io, but you can also [hop on IRC](/community/irc/) for a quick chat.
+
+See the other links in the community section for more information about meetings, events, apps people are building, and more.
+
+Information about contributing to libp2p and about other software projects in the community are also hosted here.
+
+
+### Get Involved
+
+libp2p is an open-source community project. While [Protocol Labs](https://protocol.ai) is able to sponsor some of the work around it, much of the design, code, and effort is contributed by volunteers and community members like you. If you’re interested in helping improve libp2p, check the [how to help](/community/contribute/how_to_help/) guide to get started.
+
+If you are diving in to contribute new code, make sure you check both the [contribution guidelines](https://github.com/libp2p/community/blob/master/CONTRIBUTE.md) and the style guide for your language ([Go](https://github.com/ipfs/community/blob/master/CONTRIBUTING_GO.md), [JavaScript](https://github.com/ipfs/community/blob/master/CONTRIBUTING_JS.md)).
+
+
+### Related Projects
+
+libp2p began as part of the [IPFS](https://ipfs.io) project, and is still an essential component of IPFS. As such, libp2p composes well with the abstractions and tools provided by other projects in the IPFS "family". Check their individual sites for specific information and references:
+
+- [IPFS](https://libp2p.io) is the InterPlanetary File System, which uses libp2p as its networking layer.
+- [Multiformats](https://multiformats.io) is a variety of *self-describing* data formats.
+- [IPLD](https://ipld.io) is a set of tools for describing links between content-addressed data, like IPFS files, Git commits, or Ethereum blocks.
+- [The Permissive License Stack](https://protocol.ai/blog/announcing-the-permissive-license-stack) is a licensing strategy for software development that embraces open-source values.


### PR DESCRIPTION
Using a symlink from the index page to the intro page results in weird breadcrumbs and is probably a bad idea anyway.

This just copies the intro page content to the index page. In the future I think they should be distinct, but this gets something up there quickly.