### PR TITLE
Use new ipfs-dns-deploy image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:1.1
+      - image: olizilla/ipfs-dns-deploy:latest
         environment:
           DOMAIN: docs.libp2p.io
           BUILD_DIR: public


### PR DESCRIPTION
The 1.2 image for ipfs-dns-deploy uses a different version if ipfs-cluster-ctl

I think the cluster may have recently updated, since the 1.1 image just stopped working