### PR TITLE
export P2PNode class

### DIFF
--- a/content/tutorials/getting-started/javascript.md
+++ b/content/tutorials/getting-started/javascript.md
@@ -83,6 +83,7 @@ class P2PNode extends Libp2p {
   }
 }
 
+module.exports = {P2PNode}
 ```
 
 The `libp2p` module exports a [libp2p.Node class](https://github.com/libp2p/js-libp2p#create-a-node---new-libp2pnodeoptions) which we extend into our own `P2PNode` class.


### PR DESCRIPTION
current snippet doesn't export P2PNode class, so when you try to require it in `src/index.js` it doesn't find the class returning an error:
```
const peer = new P2PNode({peerInfo})
^
TypeError: P2PNode is not a constructor
```

so that change should export P2PNode