### PR TITLE
fix: js ping tutorial

### DIFF
--- a/content/tutorials/getting-started/javascript.md
+++ b/content/tutorials/getting-started/javascript.md
@@ -236,7 +236,7 @@ Let's add a `ping` method to our `P2PNode` class so we can send pings to other p
 Change the definition of `P2PNode` in `src/p2p/index.js` to this:
 
 ```javascript
-const Ping = require('libp2p-ping')
+const Ping = require('libp2p/src/ping')
 
 class P2PNode extends Libp2p {
   constructor (opts) {


### PR DESCRIPTION
With the latest refactor released with [libp2p/js-libp2p400](https://github.com/libp2p/js-libp2p/pull/400), [libp2p/js-libp2p-ping](https://github.com/libp2p/js-libp2p-ping) module is now deprecated.