### PR TITLE
Fixed 2 TODO links on what-is-libp2p page

### DIFF
--- a/content/introduction/what-is-libp2p.md
+++ b/content/introduction/what-is-libp2p.md
@@ -75,7 +75,7 @@ libp2p defines a [pubsub interface][interface_pubsub] for sending messages to al
 [interface_pubsub]: https://github.com/libp2p/specs/tree/master/pubsub
 
 
-[built_with_libp2p]: /TODO
-[help_improve_docs]: /TODO
+[built_with_libp2p]: https://discuss.libp2p.io/c/ecosystem-community
+[help_improve_docs]: https://github.com/libp2p/docs/issues
 
 [wiki_kademlia]: https://en.wikipedia.org/wiki/Kademlia


### PR DESCRIPTION
Added live links to two dead /TODO on what-is-libp2p page found at https://docs.libp2p.io/introduction/what-is-libp2p/

Reference Issue #75 