### PR TITLE
chore: update js getting started tutorial to async

### DIFF
--- a/content/tutorials/getting-started/javascript.md
+++ b/content/tutorials/getting-started/javascript.md
@@ -6,9 +6,7 @@ weight: 2
 
 This is the first in a series of tutorials on working with libp2p's javascript implementation, [js-libp2p](https://github.com/libp2p/js-libp2p).
 
-We'll cover setting up an empty project, creating a libp2p "bundle" with some basic functionality, and finally we'll send ping messages back and forth between two peers.
-
-**ATTENTION:** This tutorial is using `js-libp2p@0.26` version. Please take into account [libp2p/js-libp2p//GETTING_STARTED.md](https://github.com/libp2p/js-libp2p/blob/master/doc/GETTING_STARTED.md) document while we work on updating this tutorial.
+We will walk you through setting up a fully functional libp2p node with some basic functionality, and finally we'll send ping messages back and forth between two peers.
 
 <!--more-->
 
@@ -42,287 +40,244 @@ We need a place to put our work, so open a terminal to make a new directory for 
 
 Side note: throughout this tutorial, we use the `> ` character to indicate your terminal's shell prompt. When following along, don't type the `>` character, or you'll get some weird errors.
 
-
-## Build a libp2p bundle
+## Configure libp2p
 
 libp2p is a very modular framework, which allows javascript devs to target different runtime environments and opt-in to various features by including a custom selection of modules.
 
-Because every application is different, we recommend building a "bundle" with just the modules you need. You can even make more than one, if you want to target multiple javascript runtimes with different features. For example, the IPFS project uses two libp2p bundles, [one for node.js](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-nodejs.js) and [one for the browser](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-browser.js).
-
-Since, we're here to learn how libp2p works, we're going to start from scratch and define our own bundle. We'll start with a very simple bundle and add features as we need them.
-
-First, install the `libp2p` dependency. We'll also need at least one transport module, so we'll pull in `libp2p-tcp` as well, and the `@nodeutils/defaults-deep` helper which we'll use when building the bundle.
-
-```shell
-npm install --save libp2p libp2p-tcp @nodeutils/defaults-deep
-```
+Because every application is different, we recommend configuring your libp2p node with just the modules you need. You can even make more than one configuration, if you want to target multiple javascript runtimes with different features. For example, the IPFS project has two libp2p configurations, [one for node.js](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-nodejs.js) and [one for the browser](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-browser.js).
 
 {{% notice note %}}
-In a production application, it may make sense to create a separate npm module for your bundle, which will give you one place to manage the libp2p dependencies for all your javascript projects. In that case, you should not depend on `libp2p` directly in your application. Instead you'd depend on your bundle, which would in turn depend on `libp2p` and whatever modules (transports, etc) you might need.
+In a production application, it may make sense to create a separate npm module for your libp2p node, which will give you one place to manage the libp2p dependencies for all your javascript projects. In that case, you should not depend on `libp2p` directly in your application. Instead you'd depend on your libp2p configuration module, which would in turn depend on `libp2p` and whatever modules (transports, etc) you might need.
 {{% /notice %}}
 
-For this tutorial, our bundle will just be a javascript file in our application source.
+If you're new to libp2p, we recommend configuring your node in stages, as this can make troubleshooting configuration issues much easier. In this tutorial, we'll do just that. If you're more experienced with libp2p, you may wish to jump to the [Configuration readme](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md).
 
-Make a directory called `src/p2p` and a file called `src/p2p/index.js` with the following content:
+As an initial step, you should install libp2p module.
 
-```javascript
+```shell
+npm install libp2p
+```
+
+### Basic setup
+
+Now that we have libp2p installed, let's configure the minimum needed to get your node running. The only modules libp2p requires are a **Transport** and **Crypto** module. However, we recommend that a basic setup should also have a **Stream Multiplexer** configured, which we will explain shortly. Let's start by setting up a Transport.
+
+#### Transports
+
+Libp2p uses Transports to establish connections between peers over the network. You can configure any number of Transports, but you only need 1 to start with.
+
+You should select Transports according to the runtime of your application; Node.js or the browser. You can see a list of some of the available Transports in the [configuration readme](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#transport). For this guide let's install `libp2p-tcp`.
+
+```sh
+npm install libp2p-tcp
+```
+
+Now that we have the module installed, let's configure libp2p to use the Transport. We'll use the [`Libp2p.create`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#create) method, which takes a single configuration object as its only parameter. We can add the Transport by passing it into the `modules.transport` array:
+
+```js
 const Libp2p = require('libp2p')
 const TCP = require('libp2p-tcp')
 
-const defaultsDeep = require('@nodeutils/defaults-deep')
-
-const DEFAULT_OPTS = {
+const node = await Libp2p.create({
   modules: {
-    transport: [
-      TCP
-    ]
+    transport: [TCP]
   }
-}
-
-class P2PNode extends Libp2p {
-  constructor (opts) {
-    super(defaultsDeep(opts, DEFAULT_OPTS))
-  }
-}
-
-module.exports = {P2PNode}
-```
-
-The `libp2p` module exports a [libp2p.Node class](https://github.com/libp2p/js-libp2p#create-a-node---new-libp2pnodeoptions) which we extend into our own `P2PNode` class.
-
-Right now our class just adds the `libp2p-tcp` transport module to the default constructor options of the base class. As we go, we'll extend our bundle to include more transports and configure other aspects of the libp2p stack.
-
-## Create an instance of a libp2p node
-
-Using the bundle we defined above, we can create a new `P2PNode` instance.
-
-To do so, create a file called `src/index.js` and make it look like this:
-
-```javascript
-const multiaddr = require('multiaddr')
-const PeerInfo = require('peer-info')
-const {P2PNode} = require('./p2p')
-
-function createPeer(callback) {
-  // create a new PeerInfo object with a newly-generated PeerId
-  PeerInfo.create((err, peerInfo) => {
-    if (err) {
-      return callback(err)
-    }
-
-    // add a listen address to accept TCP connections on a random port
-    const listenAddress = multiaddr(`/ip4/127.0.0.1/tcp/0`)
-    peerInfo.multiaddrs.add(listenAddress)
-
-    const peer = new P2PNode({peerInfo})
-    // register an event handler for errors.
-    // here we're just going to print and re-throw the error
-    // to kill the program
-    peer.on('error', err => {
-      console.error('libp2p error: ', err)
-      throw err
-    })
-
-    callback(null, peer)
-  })
-}
-```
-
-We start out by importing a few modules. Apart from the `P2PNode` bundle we defined earlier, we have `multiaddr`, the javascript [multiaddress][definition_muiltiaddress] library, and `peer-info`, which contains a [PeerId][definition_peerid] and a set of multiaddresses that are associated with a peer.
-
-The constructor for our bundle requires a `peerInfo` argument. This can either be generated on-the-fly or loaded from a byte buffer or JSON object. In our `createPeer` function, we're generating a new `PeerInfo` object for our peer using [`PeerInfo.create`](https://github.com/libp2p/js-peer-info#peerinfocreateid--callback). This will generate a new `PeerId` containing a newly-generated cryptographic key pair.
-
-{{% notice note %}}
-Because generating the key pair requires some computation, `PeerInfo.create` is an asynchronous operation. libp2p uses node-style callbacks for most asynchronous operations, and real-world code and more complex examples will often use helpers like [async/waterfall](https://caolan.github.io/async/docs.html#waterfall) to compose chains of async operations. Since this is a fairly simple example, we're just going to use the callbacks as-is and chain them together the "old fashioned way".
-{{% /notice %}}
-
-Once we have our `PeerInfo`, we next create a [multiaddress][definition_muiltiaddress] for `/ip4/127.0.0.1/tcp/0`, which is the [localhost IPv4 address](https://en.wikipedia.org/wiki/Localhost) on the special TCP port `0`. Using port `0` tells the operating system to randomly assign us an open port.
-
-Adding the new multiaddr to our `PeerInfo` object will cause our node to try to listen on that address when the node starts.
-
-Next we create our peer, passing in the `peerInfo` constructor option, and we register a simple error handler to catch errors that might occur during the lifetime of our peer.
-
-## Start the node and listen for connections
-
-Now we can call the `createPeer` function above and start listening for connections.
-
-Just below the `createPeer` function definition, add some code to start the peer and print our listening address:
-
-```javascript
-function handleStart(peer) {
-      // get the list of addresses for our peer now that it's started.
-      // there should be one address of the form
-      // `/ip4/127.0.0.1/tcp/${assignedPort}/ipfs/${generatedPeerId}`,
-      // where `assignedPort` is randomly chosen by the operating system
-      // and `generatedPeerId` is generated in the `createPeer` function above.
-      const addresses = peer.peerInfo.multiaddrs.toArray()
-      console.log('peer started. listening on addresses:')
-      addresses.forEach(addr => console.log(addr.toString()))
-}
-
-
-// main entry point
-createPeer((err, peer) => {
-  if (err) {
-    throw err
-  }
-
-  peer.start(err => {
-    if (err) {
-      throw err
-    }
-
-    handleStart(peer)
-  })
 })
+```
+
+You can add as many transports as you like to `modules.transport` in order to establish connections with as many peers as possible.
+
+#### Connection Encryption
+
+Every connection must be encrypted to help ensure security for everyone. As such, Connection Encryption (Crypto) is a required component of libp2p.
+
+There are a growing number of Crypto modules being developed for libp2p. As those are released they will be tracked in the [Connection Encryption section of the configuration readme](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#connection-encryption). For now, we are going to configure our node to use the `libp2p-secio` module.
+
+```sh
+npm install libp2p-secio
+```
+
+```js
+const Libp2p = require('libp2p')
+const TCP = require('libp2p-tcp')
+const SECIO = require('libp2p-secio')
+
+const node = await Libp2p.create({
+  modules: {
+    transport: [TCP],
+    connEncryption: [SECIO]
+  }
+})
+```
+
+#### Multiplexing
+
+While multiplexers are not strictly required, they are highly recommended as they improve the effectiveness and efficiency of connections for the various protocols libp2p runs.
+
+Looking at the [available stream multiplexing](https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#stream-multiplexing) modules, js-libp2p currently only supports `libp2p-mplex`, so we will use that here. You can install `libp2p-mplex` and add it to your libp2p node as follows in the next example.
+
+```sh
+npm install libp2p-mplex
+```
+
+```js
+const Libp2p = require('libp2p')
+const TCP = require('libp2p-tcp')
+const SECIO = require('libp2p-secio')
+const MPLEX = require('libp2p-mplex')
+
+const node = await Libp2p.create({
+  modules: {
+    transport: [TCP],
+    connEncryption: [SECIO],
+    streamMuxer: [MPLEX]
+  }
+})
+```
+
+#### Running Libp2p
+
+Now that you have configured a **Transport**, **Crypto** and **Stream Multiplexer** module, you can start your libp2p node. We can start and stop libp2p using the [`libp2p.start()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#start) and [`libp2p.stop()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#stop) methods.
+
+A libp2p node needs to have a listen address for the given transport, so that it can be reached by other nodes in the network. Accordingly, we will install the `multiaddr` module to create a tcp [multiaddress](definition_muiltiaddress) and add it to the node.
+
+```js
+const Libp2p = require('libp2p')
+const TCP = require('libp2p-tcp')
+const SECIO = require('libp2p-secio')
+const MPLEX = require('libp2p-mplex')
+
+const multiaddr = require('multiaddr')
+
+const main = async () => {
+  const node = await Libp2p.create({
+    modules: {
+      transport: [TCP],
+      connEncryption: [SECIO],
+      streamMuxer: [MPLEX]
+    }
+  })
+
+  // add a listen address (localhost) to accept TCP connections on a random port
+  const listenAddress = multiaddr(`/ip4/127.0.0.1/tcp/0`)
+  node.peerInfo.multiaddrs.add(listenAddress)
+
+  // start libp2p
+  await node.start()
+  console.log('libp2p has started')
+
+  // print out listening addresses
+  const addresses = node.peerInfo.multiaddrs.toArray()
+  console.log('listening on addresses:')
+  addresses.forEach(addr => {
+    console.log(`${addr.toString()}/p2p/${node.peerInfo.id.toB58String()}`)
+  })
+
+  // stop libp2p
+  await node.stop()
+  console.log('libp2p has stopped')
+}
+
+main()
 ```
 
 Try running the code with `node src/index.js`. You should see something like:
 
 ```
-peer started. listening on addresses:
-/ip4/127.0.0.1/tcp/54093/ipfs/QmPfH3qx5fyfUgxacrZ1WNC1GwXmY5kWzns3Fc9KAwZRgJ
+libp2p has started
+listening on addresses:
+/ip4/127.0.0.1/tcp/50626/p2p/QmYoqzFj5rhzFy7thCPPGbDkDkLMbQzanxCNwefZd3qTkz
+libp2p has stopped
 ```
-
-Each time you run the program, you should see a different tcp port number and PeerId hash (the `QmPfH3qx5fyfUgxacrZ1WNC1GwXmY5kWzns3Fc9KAwZRgJ` string above).
-
-## Add multiplexing and encryption
-
-We can now start a node and listen for connections, but we can't really do anything yet. This is because we're missing a key libp2p component called a [stream multiplexer][definition_multiplexer], which lets us interleave multiple independent streams of communication across one network connection.
-
-While we're at it, we'll also add support for encrypted communication, which is something most real-world applications will need to support.
-
-Lets add two new dependencies:
-
-```shell
-npm install --save libp2p-mplex libp2p-secio
-```
-
-And we'll need to edit our bundle. Open `src/p2p/index.js` and import the new modules:
-
-```javascript
-const Multiplex = require('libp2p-mplex')
-const SECIO = require('libp2p-secio')
-```
-
-Then change the `DEFAULT_OPTS` constant to look like this:
-
-```javascript
-const DEFAULT_OPTS = {
-  modules: {
-    transport: [
-      TCP
-    ],
-    connEncryption: [
-      SECIO
-    ],
-    streamMuxer: [
-      Multiplex
-    ]
-  }
-}
-```
-
-Thats it! Now we can open multiple independent streams over our single TCP connection, and our connection will be upgraded to a securely encrypted channel using the [secio module](https://github.com/libp2p/js-libp2p-secio).
 
 ## Lets play ping pong!
 
 Now that we have the basic building blocks of transport, multiplexing, and security in place, we can start communicating!
 
-The base `libp2p.Node` class that we based our bundle on registers one built-in protocol handler for us, the [ping protocol](https://github.com/libp2p/js-libp2p-ping). That means that other peers can dial us and send us ping messages, and we'll send back a "pong" so they know we're alive and can measure the latency between us.
+We can use [`libp2p.ping()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#ping) to dial and send ping messages to another peer. That peer will send back a "pong" message, so that we know that it is still alive. This also enables us to measure the latency between peers.
 
-While we respond to pings automatically, we need to do a bit of wiring to send them.
-
-Let's add a `ping` method to our `P2PNode` class so we can send pings to other peers.
-
-Change the definition of `P2PNode` in `src/p2p/index.js` to this:
-
-```javascript
-const Ping = require('libp2p/src/ping')
-
-class P2PNode extends Libp2p {
-  constructor (opts) {
-    super(defaultsDeep(opts, DEFAULT_OPTS))
-  }
-
-  ping (remotePeerInfo, callback) {
-    const p = new Ping(this._switch, remotePeerInfo)
-    p.on('ping', time => {
-      p.stop() // stop sending pings
-      callback(null, time)
-    })
-    p.on('error', callback)
-    p.start()
-  }
-}
-```
-
-Now we can accept have our program accept the multiaddress of another peer as a command line argument and try to ping it.
-
-To do so, we'll need to add a couple things to `src/index.js`. First, require the `process` module so we can get the command line arguments:
+We can have our application accepting a peer multiaddress via command line argument and try to ping it. To do so, we'll need to add a couple things. First, require the `process` module so that we can get the command line arguments:
 
 ```javascript
 const process = require('process')
 ```
 
-Then we'll add a function to parse a multiaddress from the command line and try to ping the remote peer:
+Then we'll need to parse the multiaddress from the command line and try to ping it:
 
 ```javascript
-const PeerId = require('peer-id')
-
-function pingRemotePeer(localPeer) {
-  if (process.argv.length < 3) {
-    return console.log('no remote peer address given, skipping ping')
+const node = await Libp2p.create({
+  modules: {
+    transport: [TCP],
+    connEncryption: [SECIO],
+    streamMuxer: [MPLEX]
   }
-  const remoteAddr = multiaddr(process.argv[2])
+})
 
-  // Convert the multiaddress into a PeerInfo object
-  const peerId = PeerId.createFromB58String(remoteAddr.getPeerId())
-  const remotePeerInfo = new PeerInfo(peerId)
-  remotePeerInfo.multiaddrs.add(remoteAddr)
+// add a listen address (localhost) to accept TCP connections on a random port
+const listenAddress = multiaddr(`/ip4/127.0.0.1/tcp/0`)
+node.peerInfo.multiaddrs.add(listenAddress)
 
-  console.log('pinging remote peer at ', remoteAddr.toString())
-  localPeer.ping(remotePeerInfo, (err, time) => {
-    if (err) {
-      return console.error('error pinging: ', err)
-    }
-    console.log(`pinged ${remoteAddr.toString()} in ${time}ms`)
-  })
+// start libp2p
+await node.start()
+console.log('libp2p has started')
+
+// print out listening addresses
+const addresses = node.peerInfo.multiaddrs.toArray()
+console.log('listening on addresses:')
+addresses.forEach(addr => {
+  console.log(`${addr.toString()}/p2p/${node.peerInfo.id.toB58String()}`)
+})
+
+// ping peer if received multiaddr
+if (process.argv.length >= 3) {
+  const ma = multiaddr(process.argv[2])
+  console.log(`pinging remote peer at ${process.argv[2]}`)
+  const latency = await node.ping(ma)
+  console.log(`pinged ${process.argv[2]} in ${latency}ms`)
+} else {
+  console.log('no remote peer address given, skipping ping')
 }
-```
 
-And finally, in our `handleStart` function, just after we log our listen address, add this line:
+const stop = async () => {
+  // stop libp2p
+  await node.stop()
+  console.log('libp2p has stopped')
+  process.exit(0)
+}
 
-```javascript
-pingRemotePeer(peer)
+process.on('SIGTERM', stop)
+process.on('SIGINT', stop)
 ```
 
 Now we can start one instance with no arguments:
 
 ```shell
 > node src/index.js
-peer started. listening on addresses:
-/p2p-circuit/ipfs/QmcJWZQ3Q1q9jUwzYw1e1NN2oQG2kGocru62oGAnh4HMGL
-/p2p-circuit/ip4/127.0.0.1/tcp/0/ipfs/QmcJWZQ3Q1q9jUwzYw1e1NN2oQG2kGocru62oGAnh4HMGL
-/ip4/127.0.0.1/tcp/55780/ipfs/QmcJWZQ3Q1q9jUwzYw1e1NN2oQG2kGocru62oGAnh4HMGL
+libp2p has started
+listening on addresses:
+/ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
 no remote peer address given, skipping ping
 ```
 
 Grab the `/ip4/...` address printed above and use it as an argument to another instance.  In a new terminal:
 
 ```shell
-> node src/index.js /ip4/127.0.0.1/tcp/55780/ipfs/QmcJWZQ3Q1q9jUwzYw1e1NN2oQG2kGocru62oGAnh4HMGL
-peer started. listening on addresses:
-/p2p-circuit/ipfs/QmWXirJ9QoSnXpEAqVeEFtEAwcP8oufg1bBV2dSH41B2yt
-/p2p-circuit/ip4/127.0.0.1/tcp/0/ipfs/QmWXirJ9QoSnXpEAqVeEFtEAwcP8oufg1bBV2dSH41B2yt
-/ip4/127.0.0.1/tcp/55800/ipfs/QmWXirJ9QoSnXpEAqVeEFtEAwcP8oufg1bBV2dSH41B2yt
-pinging remote peer at  /ip4/127.0.0.1/tcp/55780/ipfs/QmcJWZQ3Q1q9jUwzYw1e1NN2oQG2kGocru62oGAnh4HMGL
-pinged /ip4/127.0.0.1/tcp/55780/ipfs/QmcJWZQ3Q1q9jUwzYw1e1NN2oQG2kGocru62oGAnh4HMGL in 6ms
+> node src/index.js /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
+libp2p has started
+listening on addresses:
+/ip4/127.0.0.1/tcp/50777/p2p/QmYZirEPREz9vSRFznxhQbWNya2LXPz5VCahRCT7caTLGm
+pinging remote peer at /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
+pinged /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN in 3ms
+^Clibp2p has stopped
 ```
 
 Success! Our two peers are now communicating over a multiplexed, secure channel.  Sure, they can only say "ping", but it's a start!
 
+## What's next?
 
+After finishing this tutorial, you should have a look into the [js-libp2p getting started](https://github.com/libp2p/js-libp2p/blob/master/doc/GETTING_STARTED.md) document, which goes from a base configuration like this one, to more custom ones.
+
+You also have a panoply of examples on [js-libp2p repo](https://github.com/libp2p/js-libp2p/tree/master/examples) that you can leverage to learn how to use `js-libp2p` for several different use cases and runtimes.
 
 [definition_muiltiaddress]: /reference/glossary/#multiaddr
 [definition_multiplexer]: /reference/glossary/#multiplexer


### PR DESCRIPTION
This PR updates the getting started tutorial to the new async API from `js-libp2p@0.27`.

Some namings were also modified, as `js-libp2p` is moving away from the `bundle` naming since this created some confusion for our users.