### PR TITLE
Google Analytics: can we do better?

### DIFF
--- a/themes/hugo-theme-learn/exampleSite/layouts/partials/custom-footer.html
+++ b/themes/hugo-theme-learn/exampleSite/layouts/partials/custom-footer.html
@@ -1,10 +1,1 @@
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-105947713-1', 'auto');
-  ga('send', 'pageview');
-
-</script>


### PR DESCRIPTION
Quite frankly, I'd like to begin this by saying: I'm a frequent user of P2P networks, such as Bittorrent, IPFS and others.

I think P2P is a perfect example of how the people can beat oppression, be it from the state or elsewhere. These technologies are hard to block, and give freedom back to the masses. I personally love the concept behind P2P, and I think we can all say: the concept is taking off quickly, worldwide...

Nevertheless, I would like to suggest this modification to you: remove Google Analytics.

Google Analytics is the antithesis of what P2P tries to achieve, getting around censorship and oppression of the state. In recent times, Google have shown themselves to be at the center of injustice, be it: stealing search history, collecting it and holding it ransom; providing data on BLM activists to the Police.

Those are a few examples. After some research, you will see thousands of cases like these, targeting *people* like yourselves.

Could we work together to remove Google from this website?

Many thanks,
Resynth <resynth1943>
https://resynth1943.net