### PR TITLE
Ping responders don't close the stream

### DIFF
--- a/content/concepts/protocols.md
+++ b/content/concepts/protocols.md
@@ -154,7 +154,7 @@ length is encoded as a [protobuf varint](https://developers.google.com/protocol-
 The ping protocol is a simple liveness check that peers can use to quickly see if another peer is online.
 
 After the initial protocol negotiation, the dialing peer sends 32 bytes of random binary data. The listening
-peer echoes the data back and closes the stream, and the dialing peer will verify the response and measure 
+peer echoes the data back, and the dialing peer will verify the response and measure 
 the latency between request and response.
 
 ### Identify


### PR DESCRIPTION
Ironically, I think rust-libp2p used to close the stream after responding to a ping, until [they concluded](https://github.com/libp2p/rust-libp2p/issues/1601) that this behaviour didn't conform to [the non-existent specification](https://github.com/libp2p/specs/issues/183).