### PR TITLE
Fixed broken links on js-libp2p getting started tutorial 

### DIFF
--- a/content/tutorials/getting-started/javascript.md
+++ b/content/tutorials/getting-started/javascript.md
@@ -44,7 +44,7 @@ Side note: throughout this tutorial, we use the `> ` character to indicate your 
 
 libp2p is a very modular framework, which allows javascript devs to target different runtime environments and opt-in to various features by including a custom selection of modules.
 
-Because every application is different, we recommend configuring your libp2p node with just the modules you need. You can even make more than one configuration, if you want to target multiple javascript runtimes with different features. For example, the IPFS project has two libp2p configurations, [one for node.js](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-nodejs.js) and [one for the browser](https://github.com/ipfs/js-ipfs/tree/master/src/core/runtime/libp2p-browser.js).
+Because every application is different, we recommend configuring your libp2p node with just the modules you need. You can even make more than one configuration, if you want to target multiple javascript runtimes with different features. For example, the IPFS project has two libp2p configurations, [one for node.js](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-core/src/runtime/libp2p-nodejs.js) and [one for the browser](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-core/src/runtime/libp2p-browser.js).
 
 {{% notice note %}}
 In a production application, it may make sense to create a separate npm module for your libp2p node, which will give you one place to manage the libp2p dependencies for all your javascript projects. In that case, you should not depend on `libp2p` directly in your application. Instead you'd depend on your libp2p configuration module, which would in turn depend on `libp2p` and whatever modules (transports, etc) you might need.
@@ -139,7 +139,7 @@ const node = await Libp2p.create({
 
 Now that you have configured a **Transport**, **Crypto** and **Stream Multiplexer** module, you can start your libp2p node. We can start and stop libp2p using the [`libp2p.start()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#start) and [`libp2p.stop()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#stop) methods.
 
-A libp2p node needs to have a listen address for the given transport, so that it can be reached by other nodes in the network. Accordingly, we will install the `multiaddr` module to create a tcp [multiaddress](definition_muiltiaddress) and add it to the node.
+A libp2p node needs to have a listen address for the given transport, so that it can be reached by other nodes in the network. Accordingly, we will install the `multiaddr` module to create a tcp [multiaddress](https://docs.libp2p.io/reference/glossary/#multiaddr) and add it to the node.
 
 ```js
 const Libp2p = require('libp2p')
@@ -266,7 +266,7 @@ listening on addresses:
 /ip4/127.0.0.1/tcp/50777/p2p/QmYZirEPREz9vSRFznxhQbWNya2LXPz5VCahRCT7caTLGm
 pinging remote peer at /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
 pinged /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN in 3ms
-^Clibp2p has stopped
+libp2p has stopped
 ```
 
 Success! Our two peers are now communicating over a multiplexed, secure channel.  Sure, they can only say "ping", but it's a start!

--- a/content/tutorials/getting-started/javascript.md
+++ b/content/tutorials/getting-started/javascript.md
@@ -139,7 +139,7 @@ const node = await Libp2p.create({
 
 Now that you have configured a **Transport**, **Crypto** and **Stream Multiplexer** module, you can start your libp2p node. We can start and stop libp2p using the [`libp2p.start()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#start) and [`libp2p.stop()`](https://github.com/libp2p/js-libp2p/blob/master/doc/API.md#stop) methods.
 
-A libp2p node needs to have a listen address for the given transport, so that it can be reached by other nodes in the network. Accordingly, we will install the `multiaddr` module to create a tcp [multiaddress](https://docs.libp2p.io/reference/glossary/#multiaddr) and add it to the node.
+A libp2p node needs to have a listen address for the given transport, so that it can be reached by other nodes in the network. Accordingly, we will install the `multiaddr` module to create a tcp [multiaddress][definition_multiaddress] and add it to the node.
 
 ```js
 const Libp2p = require('libp2p')
@@ -277,6 +277,6 @@ After finishing this tutorial, you should have a look into the [js-libp2p gettin
 
 You also have a panoply of examples on [js-libp2p repo](https://github.com/libp2p/js-libp2p/tree/master/examples) that you can leverage to learn how to use `js-libp2p` for several different use cases and runtimes.
 
-[definition_muiltiaddress]: /reference/glossary/#multiaddr
+[definition_multiaddress]: /reference/glossary/#multiaddr
 [definition_multiplexer]: /reference/glossary/#multiplexer
 [definition_peerid]: /reference/glossary/#peerid


### PR DESCRIPTION
This PR addresses Issue #80. It seems that the links to the `libp2p-nodejs.js` and `libp2p-browser.js` files constantly change, but hopefully the links that I put will not break in the future. Additionally, there is a broken link in the page that points to the definition of a multiaddress. As a fix, I instead pointed the link to the glossary entry for the multiaddress. Finally the output in the terminal shows the `^C` control character which I am guessing came from copying the terminal output after killing the ping server. This control character was removed from the output.