### PR TITLE
Fixed IRC link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -35,7 +35,7 @@ In addition to the implementations above, the libp2p community is actively worki
 
 ## Community
 
-Get in touch with other members of the libp2p community who are building tools and applications with libp2p! You can ask questions, discuss new ideas, or get support for problems at https://discuss.ipfs.io, but you can also [hop on IRC](/community/irc/) for a quick chat.
+Get in touch with other members of the libp2p community who are building tools and applications with libp2p! You can ask questions, discuss new ideas, or get support for problems at the [IPFS discussion forums](https://discuss.ipfs.io), but you can also [hop on IRC](https://docs.ipfs.io/community/irc/) for a quick chat.
 
 See the other links in the community section for more information about meetings, events, apps people are building, and more.
 

--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -36,7 +36,7 @@ In addition to the implementations above, the libp2p community is actively worki
 
 ## Community
 
-Get in touch with other members of the libp2p community who are building tools and applications with libp2p! You can ask questions, discuss new ideas, or get support for problems at https://discuss.ipfs.io, but you can also [hop on IRC](/community/irc/) for a quick chat.
+Get in touch with other members of the libp2p community who are building tools and applications with libp2p! You can ask questions, discuss new ideas, or get support for problems at the [IPFS discussion forums](https://discuss.ipfs.io), but you can also [hop on IRC](https://docs.ipfs.io/community/irc/) for a quick chat.
 
 See the other links in the community section for more information about meetings, events, apps people are building, and more.
 

--- a/content/introduction/what-is-libp2p.md
+++ b/content/introduction/what-is-libp2p.md
@@ -19,8 +19,6 @@ Because the definition of peer-to-peer networking is quite broad, many different
 
 While peer-to-peer networks have many advantages over the client / server model, there are also challenges that are unique and require careful thought and practice to overcome. In our process of overcoming these challenges while building [IPFS](https://ipfs.io), we took care to build our solutions in a modular, composable way, into what is now libp2p. Although libp2p grew out of IPFS, it does not require or depend on IPFS, and today [many projects][built_with_libp2p] use libp2p as their network transport layer. Together we can leverage our collective experience and solve these foundational problems in a way that benefits an entire ecosystem of developers and a world of users.
 
-
-
 Here I'll try to briefly outline the main problem areas that are addressed by libp2p today (early 2019). This is an ever-growing space, so don't be surprised if things change over time. We'll do our best to keep this section up-to-date as things progress, but if you notice something missing or have other ideas for improving this documentation, please [reach out to let us know][help_improve_docs].
 
 <!-- TODO: as concept articles are written expanding on the below, add links -->
@@ -37,7 +35,7 @@ In a world with billions of networked devices, knowing who you're talking to is 
 
 It's essential that we are able to send and receive data between peers *securely*, meaning that we can trust the [identity](#identity) of the peer we're communicating with and that no third-party can read our conversation or alter it in-flight.
 
-libp2p supports "upgrading" a connection provided by a [transport](#transport) into a securely encrypted channel. The process is flexible, and can support multiple methods of encrypting communication. libp2p currently supports [TLS 1.3](https://www.ietf.org/blog/tls13/) and [Noise](https://noiseproject.org/), though not every language implementation of libp2p supports both of these. (Older versions of libp2p may support a [deprecated](https://blog.ipfs.io/2020-08-07-deprecating-secio/) protocol called SECIO; all projects should switch to TLS 1.3 or Noise instead.)
+libp2p supports "upgrading" a connection provided by a [transport](#transport) into a securely encrypted channel. The process is flexible, and can support multiple methods of encrypting communication. libp2p currently supports [TLS 1.3](https://www.ietf.org/blog/tls13/) and [Noise](http://noiseprotocol.org/), though not every language implementation of libp2p supports both of these. (Older versions of libp2p may support a [deprecated](https://blog.ipfs.io/2020-08-07-deprecating-secio/) protocol called SECIO; all projects should switch to TLS 1.3 or Noise instead.)
 
 ### Peer Routing
 
@@ -48,7 +46,6 @@ There are many cases where we only have the `PeerId` for the peer we want to con
 In a peer routing system, a peer can either give us the address we need if they have it, or else send our inquiry to another peer who's more likely to have the answer. As we contact more and more peers, we not only increase our chances of finding the peer we're looking for, we build a more complete view of the network in our own routing tables, which enables us to answer routing queries from others.
 
 The current stable implementation of peer routing in libp2p uses a [distributed hash table][definition_dht] to iteratively route requests closer to the desired `PeerId` using the [Kademlia][wiki_kademlia] routing algorithm.
-
 
 ### Content Discovery
 
@@ -73,7 +70,6 @@ libp2p defines a [pubsub interface][interface_pubsub] for sending messages to al
 
 [interface_content_routing]: https://github.com/libp2p/js-libp2p-interfaces/tree/master/src/content-routing
 [interface_pubsub]: https://github.com/libp2p/specs/tree/master/pubsub
-
 
 [built_with_libp2p]: https://discuss.libp2p.io/c/ecosystem-community
 [help_improve_docs]: https://github.com/libp2p/docs/issues


### PR DESCRIPTION
The IRC channel instructions are actually at IPFS, updated the link so it doesn't try to reference a non-existing page in libp2p docs.