### PR TITLE
content: Add Rust tutorial and correct rust-libp2p maturity level

### DIFF
--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -29,7 +29,7 @@ See the [specifications section](/reference/specs/) for details.
 
 ### Implementations
 
-At the core of libp2p is a set of [specifications](/reference/specs/), which together form the definition for what libp2p is in the abstract and what makes a "correct" libp2p implementation. Today, implementations of libp2p exist in several languages, with varying degrees of completeness. The most complete implementations are in [Go](/reference/go/) and [JavaScript](/reference/js/), with [rust](https://github.com/libp2p/rust-libp2p) maturing rapidly.
+At the core of libp2p is a set of [specifications](/reference/specs/), which together form the definition for what libp2p is in the abstract and what makes a "correct" libp2p implementation. Today, implementations of libp2p exist in several languages, with varying degrees of completeness. The most complete implementations are in [Go](/reference/go/), [JavaScript](/reference/js/), and [Rust](https://github.com/libp2p/rust-libp2p).
 
 In addition to the implementations above, the libp2p community is actively working on implementations in [python](https://github.com/libp2p/py-libp2p) and [the JVM via Kotlin](https://github.com/web3j/libp2p). Please check the project pages for each implementation to see its status and current state of completeness.
 

--- a/content/tutorials/getting-started/rust.md
+++ b/content/tutorials/getting-started/rust.md
@@ -1,0 +1,8 @@
+---
+title: "Getting Started with rust-libp2p"
+menuTitle: Rust
+weight: 1
+---
+
+Check out [the tutorial of the Rust libp2p
+implementation](https://docs.rs/libp2p/newest/libp2p/tutorial/index.html).


### PR DESCRIPTION
This commit links to the main rust-libp2p tutorial in the getting
started section. In addition, given that rust-libp2p is a stable
implementation of the libp2p specification, used in production, mention
rust-libp2p along with go-libp2p and js-libp2p.

---


@momack2 linking the tutorial here as discussed. Could you give this pull request a review?