### PR TITLE
Fix multiaddr import

### DIFF
--- a/content/tutorials/getting-started/javascript.md
+++ b/content/tutorials/getting-started/javascript.md
@@ -147,7 +147,7 @@ const TCP = require('libp2p-tcp')
 const { NOISE } = require('libp2p-noise')
 const MPLEX = require('libp2p-mplex')
 
-const multiaddr = require('multiaddr')
+const { multiaddr } = require('multiaddr')
 
 const main = async () => {
   const node = await Libp2p.create({


### PR DESCRIPTION
Following the javascript tutorial, I had the following error:

```
(node:19968) UnhandledPromiseRejectionWarning: TypeError: multiaddr is not a function       
    at main (C:\...\hello-libp2p\src\index.js:34:16)
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
(node:19968) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting 
a promise which was not handled with .catch(). (rejection id: 1)
(node:19968) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Looking at the [js-multiaddr repo](https://github.com/multiformats/js-multiaddr/blob/7d284e4ce9285b448cd1287af9702a62ff696d68/README.md), the correct usage for the `"^9.0.1"` version should be:

```javascript
// if we are coming from <= 8.x you can use the factory function 
const { multiaddr } = require('multiaddr')
const addr =  multiaddr("/ip4/127.0.0.1/udp/1234")
```

