### PR TITLE
Fixed a broken link to PeerId

### DIFF
--- a/content/concepts/addressing.md
+++ b/content/concepts/addressing.md
@@ -12,7 +12,7 @@ For example: `/ip4/127.0.0.1/udp/1234` encodes two protocols along with their es
 Things get more interesting as we compose further. For example, the multiaddr `/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N` uniquely identifies my local IPFS node, using libp2p's [registered protocol id](https://github.com/multiformats/multiaddr/blob/master/protocols.csv) `/p2p/` and the [multihash](/reference/glossary/#multihash) of my IPFS node's public key.
 
 {{% notice "tip" %}}
-For more on peer identity and its relation to public key cryptography, see [Peer Identity](./peer-identity/).
+For more on peer identity and its relation to public key cryptography, see [Peer Identity](./peer-id/).
 {{% /notice %}}
 
 Let's say that I have the peer id `QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N` as above, and my public ip is `7.7.7.7`. I start my libp2p application and listen for connections on TCP port `4242`.


### PR DESCRIPTION
In the original version [the Addressing section](https://docs.libp2p.io/concepts/addressing/) contains a broken link to Peer Identity inside the tip.

The link leads to [https://docs.libp2p.io/concepts/addressing/peer-identity/](https://docs.libp2p.io/concepts/addressing/peer-identity/) which returns the error:
`ipfs resolve -r /ipns/docs.libp2p.io/concepts/addressing/peer-identity/: no link named "peer-identity" under bafybeihj4dcfauzvivw5nmukwvccttdl7zocicoa4vqeacz7dur75v7k24`

The fix is simply changing './peer-identity' to './peer-id'.

