### PR TITLE
Fix missing context import in main function

### DIFF
--- a/content/tutorials/getting-started/go.md
+++ b/content/tutorials/getting-started/go.md
@@ -348,7 +348,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-    "context"
+    	"context"
 
 	"github.com/libp2p/go-libp2p"
 	peerstore "github.com/libp2p/go-libp2p-core/peer"
@@ -382,7 +382,7 @@ func main() {
 	}
 	fmt.Println("libp2p node address:", addrs[0])
 
-	ctx:=context.Background()
+	ctx := context.Background()
 
 	// if a remote peer has been passed on the command line, connect to it
 	// and send it 5 ping messages, otherwise wait for a signal to stop

--- a/content/tutorials/getting-started/go.md
+++ b/content/tutorials/getting-started/go.md
@@ -348,6 +348,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+    "context"
 
 	"github.com/libp2p/go-libp2p"
 	peerstore "github.com/libp2p/go-libp2p-core/peer"
@@ -380,6 +381,8 @@ func main() {
 		panic(err)
 	}
 	fmt.Println("libp2p node address:", addrs[0])
+
+	ctx:=context.Background()
 
 	// if a remote peer has been passed on the command line, connect to it
 	// and send it 5 ping messages, otherwise wait for a signal to stop

--- a/content/tutorials/getting-started/go.md
+++ b/content/tutorials/getting-started/go.md
@@ -348,7 +348,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-    	"context"
+	"context"
 
 	"github.com/libp2p/go-libp2p"
 	peerstore "github.com/libp2p/go-libp2p-core/peer"


### PR DESCRIPTION
Imported "context"  in the main function and added the definition for ctx in the main function.