### PR TITLE
fix(link): Go example links

### DIFF
--- a/content/examples/_index.md
+++ b/content/examples/_index.md
@@ -6,6 +6,6 @@ pre: '<i class="fas fa-fw fa-code"></i> '
 
 Here's where to find working examples illustrating some of libp2p's key features for each of its main implementations:
 
-* For go, see the [go-libp2p-examples repo](https://github.com/libp2p/go-libp2p-examples).
+* For go, see the [go-libp2p-examples repo](https://github.com/libp2p/go-libp2p/tree/master/examples).
 * For javascript, see the [/examples directory of the js-libp2p repo](https://github.com/libp2p/js-libp2p/tree/master/examples).
 * For rust, see [/examples directory of the rust-libp2p repo](https://github.com/libp2p/rust-libp2p/tree/master/examples).


### PR DESCRIPTION
Hej;
I recognized that the current documentation is pointing to an archived repository. This PR redirects the user to the correct location without any hop in between.

Cheers!