### PR TITLE
Update protocols.md

### DIFF
--- a/content/concepts/protocols.md
+++ b/content/concepts/protocols.md
@@ -46,7 +46,7 @@ developer-friendly and enables [easier matching by version](#match-using-semver)
 #### Handler functions
 
 To accept connections, a libp2p application will register handler functions for protocols using their protocol id with the
-[switch][definition_switch] (aka "swarm"), or a higher level interface such as [go's Host interface](https://github.com/libp2p/go-libp2p-host/blob/master/host.go).
+[switch][definition_switch] (aka "swarm"), or a higher level interface such as [go's Host interface](https://github.com/libp2p/go-libp2p-core/blob/master/host/host.go).
 
 The handler function will be invoked when an incoming stream is tagged with the registered protocol id.
 If you register your handler with a [match function](#using-a-match-function), you can choose whether


### PR DESCRIPTION
Update link in Handler Function section because the old repo was depreceated and archived.
From https://github.com/libp2p/go-libp2p-host repo to > https://github.com/libp2p/go-libp2p-core/blob/master/host/host.go