### PR TITLE
Fix link for Rust tutorials

### DIFF
--- a/content/tutorials/getting-started/rust.md
+++ b/content/tutorials/getting-started/rust.md
@@ -4,5 +4,5 @@ menuTitle: Rust
 weight: 1
 ---
 
-Check out [the tutorial of the Rust libp2p
-implementation](https://docs.rs/libp2p/newest/libp2p/tutorial/index.html).
+Check out [tutorials of the Rust libp2p
+implementation](https://docs.rs/libp2p/newest/libp2p/tutorials/index.html).


### PR DESCRIPTION
This fixes the link for Rust tutorials as the old one was outdated.