### PR TITLE
Fix link for Protocol Negotiation

### DIFF
--- a/content/concepts/transport.md
+++ b/content/concepts/transport.md
@@ -100,7 +100,7 @@ in a web browser.
 
 The libp2p component responsible for managing the transports is called the
 [switch][definition_switch], which also coordinates
-[protocol negotiation](/concepts/protocol-negotiation),
+[protocol negotiation](/concepts/protocols/#protocol-negotiation),
 [stream multiplexing](/concepts/stream-multiplexing),
 [establishing secure communication](/concepts/secure-comms/) and other forms of
 "connection upgrading".


### PR DESCRIPTION
The Transports concepts page links to the "Protocol Negotiation" page but this hase moved under the "Protocol" page under its own heading.