### PR TITLE
Add missing link to the S/Kademlia paper

### DIFF
--- a/content/concepts/security-considerations.md
+++ b/content/concepts/security-considerations.md
@@ -160,3 +160,4 @@ determined bad actors.
 [concepts-peer-routing]: ../peer-routing/
 [concepts-content-routing]: ../content-routing/
 [wikipedia-sybil]: https://en.wikipedia.org/wiki/Sybil_attack
+[paper-s-kademlia]: https://telematics.tm.kit.edu/publications/Files/267/SKademlia_2007.pdf


### PR DESCRIPTION
Added the missing link for the S/Kademlia paper referenced in the docs on securing routing as linked by one of [the authors' on their Karlsruher Institute of Technology pages.](https://telematics.tm.kit.edu/article.php?publication_id=267&language_id=1)