### PR TITLE
Corrected typo in Introduction: Data Transmission

### DIFF
--- a/content/introduction/_index.md
+++ b/content/introduction/_index.md
@@ -74,7 +74,7 @@ ways to send data across networks in use today, including TCP, QUIC, WebSocket,
 WebTransport and WebRTC, with some still in development and others still yet 
 to be designed. 
 
-libp2p also provides a list of specifications [specifcations](https://github.com/libp2p/specs) 
+libp2p also provides a list of [specifications](https://github.com/libp2p/specs) 
 that can be adapted to support existing and future protocols, allowing libp2p applications 
 to operate in many different runtime and networking environments.
 


### PR DESCRIPTION
Line 77 had duplicated "specifications" with a spelling error in the link. This fork corrects that typo.