### PR TITLE
Add connectivity site references

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,5 +33,10 @@ name = "<i class='fab fa-discourse'></i> Discussion Forums"
 url = "https://discuss.libp2p.io"
 weight = 4
 
+[[menu.shortcuts]]
+name = "<i class='fab fa-discourse'></i> Connectivity"
+url = "https://connectivity.libp2p.io"
+weight = 5
+
 [markup.goldmark.renderer]
   unsafe = true # Allow HTML in md files

--- a/config.toml
+++ b/config.toml
@@ -34,7 +34,7 @@ url = "https://discuss.libp2p.io"
 weight = 4
 
 [[menu.shortcuts]]
-name = "<i class='fab fa-discourse'></i> Connectivity"
+name = "<i class='fas fa-book'></i> Connectivity"
 url = "https://connectivity.libp2p.io"
 weight = 5
 

--- a/content/concepts/transports/_index.md
+++ b/content/concepts/transports/_index.md
@@ -31,4 +31,8 @@ of what transport protocol to use is up to the developer, and an application can
 many different transports at the same time. Learn about the fundamentals of transport 
 protocols in libp2p.
 
+To better visualize the types of libp2p connections, check out the
+[connectivity site](https://connectivity.libp2p.io/) which outlines the different types 
+of connectivity in libp2p.
+
 {{% children description="true"%}}

--- a/content/reference/connectivity.md
+++ b/content/reference/connectivity.md
@@ -1,0 +1,11 @@
+---
+title: "Connectivity"
+weight: 2
+pre: '<i class="fas fa-fw fa-book"></i> <b> </b>'
+chapter: true
+summary: libp2p enables universal connectivity between nodes across different network positions by supporting a wide range of transport protocols.
+---
+
+# Connectivity in libp2p
+
+Check out the [connectivity site](https://connectivity.libp2p.io/) for types of connectivity in libp2p.


### PR DESCRIPTION
## Context

Adds references to the new connectivity site: connectivity.libp2p.io
- Added a simple reference section doc.
- Added to left nav bar.
- Added ending sentence on the transport index.
- closes #218 

## Latest preview

Please view the latest Fleek preview [here](https://bafybeieqpsuyt7tz7un5pyiqsljtevziytx35m7wweuygrjwsojgrezgv4.on.fleek.co/).