### PR TITLE
Typo

### DIFF
--- a/content/concepts/transports/webrtc.md
+++ b/content/concepts/transports/webrtc.md
@@ -3,6 +3,6 @@ title: "WebRTC"
 weight: 4
 pre: '<i class="fas fa-fw fa-book"></i> <b> </b>'
 chapter: true
-summary: WebRTC is a new specification that uses QUIC to offer an alternative to WebSocket. Conceptually, it can be considered WebSocket over QUIC.Learn about WebTransport and how it is used in libp2p.
+summary: WebRTC is a new specification that uses QUIC to offer an alternative to WebSocket. Conceptually, it can be considered WebSocket over QUIC. Learn about WebRTC and how it is used in libp2p.
 ---
 


### PR DESCRIPTION
Replaces "WebTransport" by "WebRTC" as it should read