### PR TITLE
add: context for quicv1

### DIFF
--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -114,7 +114,6 @@ Nodes that support multiple versions can offer them on the same port.
 Since QUIC packets contain the version number and any (multi-version)
 QUIC stack will be able to handle packets from different QUIC versions,
 
-
 {{< alert icon="💡" context="note" text="With the upcoming <a class=\"text-muted\" href=\"https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/\">Compatible Version Negotiation for QUIC</a> specification, it will become possible to do a version upgrade between two compatible versions without incurring any round-trip penalty." />}}
 
 ## References

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -98,17 +98,17 @@ IDs are authenticated in the
 Following the multiaddress format, a standard QUIC connection will
 look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
 
-### QUIC code point
+### QUIC code points
 
 The initial implementation of QUIC of go-libp2p was based on
 [draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
 (or simply, **draft-29**), because [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
 was yet to be finalized. Some legacy nodes on the IPFS network still use draft-29.
-By using different code points (`quic-v1` for RFC 9000 and `quic` for draft-29,
+By using different code points (`quic-v1` for RFC 9000 and `quic` for draft-29),
 we can distinguish between the two versions.
 
-A standard QUIC connection will look like: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the initial
-codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) implies to draft-29.
+A standard QUIC connection will look like: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the
+initial codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) implies draft-29.
 
 Nodes that support multiple versions can offer them on the same port.
 Since QUIC packets contain the version number and any (multi-version)

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -95,8 +95,30 @@ IDs are authenticated in the
 
 {{< alert icon="💡" context="note" text="To be clear, there is no additional security handshake and stream muxer needed as QUIC provides all of this by default. This also means that establishing a libp2p connection between two nodes using QUIC only takes a single RTT." />}}
 
-Following the multiaddress format described earlier, a standard QUIC connection will
+Following the multiaddress format, a standard QUIC connection will
 look like: `/ip4/127.0.0.1/udp/65432/quic/`.
+
+### QUIC v1
+
+The initial implementation of QUIC for some implementations (e.g. go-libp2p),
+"QUIC v0", was based on
+[draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
+(or simply, **draft-29**) by the IETF as [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
+was yet to be deployed. Many nodes still use draft-29 as their deployed version. A codepoint, `quicv1`,
+is used to distinguish between the two versions.
+
+A standard QUIC v1 connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the original
+codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) defaults to draft-29.
+
+Nodes that support multiple versions can offer them on the same port.
+Since QUIC packets contain the version number and any (multi-version)
+QUIC stack will be able to handle packets from different QUIC versions,
+demultiplexing works as intended.
+
+Due to version negotiation, a 1 RTT penalty will incur when connecting a QUIC v1 node to a
+legacy node.
+
+{{< alert icon="💡" context="note" text="With the upcoming <a class=\"text-muted\" href=\"https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/\">Compatible Version Negotiation for QUIC</a> specification, it will become possible to do a version upgrade between two compatible versions without incurring any round-trip penalty." />}}
 
 ## References
 

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -100,8 +100,7 @@ look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
 
 ### QUIC code point
 
-The initial implementation of QUIC of go-libp2p
-The original QUIC specification was based on
+The initial implementation of QUIC of go-libp2p was based on
 [draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
 (or simply, **draft-29**), because [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
 was yet to be finalized. Some legacy nodes on the IPFS network still use draft-29.

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -100,15 +100,15 @@ look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
 
 ### QUIC code point
 
-The initial implementation of QUIC for some implementations (e.g. go-libp2p),
-"QUIC v0", was based on
+The initial implementation of QUIC of go-libp2p
+The original QUIC specification was based on
 [draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
-(or simply, **draft-29**) by the IETF as [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
-was yet to be finalized. Many nodes still use draft-29 as their deployed version.
+(or simply, **draft-29**), because [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
+was yet to be finalized. Some legacy nodes on the IPFS network still use draft-29.
 By using different code points (`quic-v1` for RFC 9000 and `quic` for draft-29,
 we can distinguish between the two versions.
 
-A standard QUIC connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the initial
+A standard QUIC connection will look like: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the initial
 codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) implies to draft-29.
 
 Nodes that support multiple versions can offer them on the same port.

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -98,21 +98,22 @@ IDs are authenticated in the
 Following the multiaddress format, a standard QUIC connection will
 look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
 
-### QUIC code points
+### Distinguishing multiple QUIC versions in libp2p
 
-The initial implementation of QUIC of go-libp2p was based on
+The initial implementation of QUIC in go-libp2p was based on
 [draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
-(or simply, **draft-29**), because [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
-was yet to be finalized. Some legacy nodes on the IPFS network still use draft-29.
-By using different code points (`quic-v1` for RFC 9000 and `quic` for draft-29),
-we can distinguish between the two versions.
+(or simply, **draft-29**). At the time, draft-29 was implemented because [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
+was yet to be finalized.
+Eventually go-libp2p added support for RFC 9000 in addition to draft-29, supporting two QUIC versions.
+However, the multiaddresses for these versions used the same format and thus were indistinguishable.
 
-A standard QUIC connection will look like: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the
-initial codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) implies draft-29.
+By using different code points, `quic-v1` for RFC 9000 and `quic` for draft-29,
+libp2p can distinguish between the two versions.
+
+The multiaddress for a QUIC listener accepting RFC 9000 connections looks like this: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the for the draft version, the multiaddress would be `/ip4/1.2.3.4/udp/65432/quic/`.
 
 Nodes that support multiple versions can offer them on the same port.
-Since QUIC packets contain the version number and any (multi-version)
-QUIC stack will be able to handle packets from different QUIC versions,
+QUIC long header packets contain the version number, which enables the QUIC stack to handle multiple versions.
 
 {{< alert icon="💡" context="note" text="With the upcoming <a class=\"text-muted\" href=\"https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/\">Compatible Version Negotiation for QUIC</a> specification, it will become possible to do a version upgrade between two compatible versions without incurring any round-trip penalty." />}}
 

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -105,10 +105,10 @@ The initial implementation of QUIC in go-libp2p was based on
 (or simply, **draft-29**). At the time, draft-29 was implemented because [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
 was yet to be finalized.
 Eventually go-libp2p added support for RFC 9000 in addition to draft-29, supporting two QUIC versions.
-However, the multiaddresses for these versions used the same format and thus were indistinguishable.
+However, the multiaddresses for these versions used the same format and thus were indistinguishable in the past.
 
 By using different code points, `quic-v1` for RFC 9000 and `quic` for draft-29,
-libp2p can distinguish between the two versions.
+libp2p can now distinguish between the two versions.
 
 The multiaddress for a QUIC listener accepting RFC 9000 connections looks like this: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the for the draft version, the multiaddress would be `/ip4/1.2.3.4/udp/65432/quic/`.
 

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -98,14 +98,15 @@ IDs are authenticated in the
 Following the multiaddress format, a standard QUIC connection will
 look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
 
-### QUIC v0
+### QUIC code point
 
 The initial implementation of QUIC for some implementations (e.g. go-libp2p),
 "QUIC v0", was based on
 [draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
 (or simply, **draft-29**) by the IETF as [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
-was yet to be finalized. Many nodes still use draft-29 as their deployed version. A codepoint, `quicv1`,
-is used to distinguish between the two versions.
+was yet to be finalized. Many nodes still use draft-29 as their deployed version.
+By using different code points (`quic-v1` for RFC 9000 and `quic` for draft-29,
+we can distinguish between the two versions.
 
 A standard QUIC connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the initial
 codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) implies to draft-29.

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -96,9 +96,9 @@ IDs are authenticated in the
 {{< alert icon="💡" context="note" text="To be clear, there is no additional security handshake and stream muxer needed as QUIC provides all of this by default. This also means that establishing a libp2p connection between two nodes using QUIC only takes a single RTT." />}}
 
 Following the multiaddress format, a standard QUIC connection will
-look like: `/ip4/127.0.0.1/udp/65432/quic/`.
+look like: `/ip4/127.0.0.1/udp/65432/quicv1/`.
 
-### QUIC v1
+### QUIC v0
 
 The initial implementation of QUIC for some implementations (e.g. go-libp2p),
 "QUIC v0", was based on
@@ -107,7 +107,7 @@ The initial implementation of QUIC for some implementations (e.g. go-libp2p),
 was yet to be deployed. Many nodes still use draft-29 as their deployed version. A codepoint, `quicv1`,
 is used to distinguish between the two versions.
 
-A standard QUIC v1 connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the original
+A standard QUIC connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the initial
 codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) defaults to draft-29.
 
 Nodes that support multiple versions can offer them on the same port.

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -108,14 +108,12 @@ was yet to be finalized. Many nodes still use draft-29 as their deployed version
 is used to distinguish between the two versions.
 
 A standard QUIC connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the initial
-codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) defaults to draft-29.
+codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) implies to draft-29.
 
 Nodes that support multiple versions can offer them on the same port.
 Since QUIC packets contain the version number and any (multi-version)
 QUIC stack will be able to handle packets from different QUIC versions,
 
-Due to version negotiation, a 1 RTT penalty will incur when connecting a QUIC v1 node to a
-legacy node.
 
 {{< alert icon="💡" context="note" text="With the upcoming <a class=\"text-muted\" href=\"https://datatracker.ietf.org/doc/draft-ietf-quic-version-negotiation/\">Compatible Version Negotiation for QUIC</a> specification, it will become possible to do a version upgrade between two compatible versions without incurring any round-trip penalty." />}}
 

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -96,7 +96,7 @@ IDs are authenticated in the
 {{< alert icon="💡" context="note" text="To be clear, there is no additional security handshake and stream muxer needed as QUIC provides all of this by default. This also means that establishing a libp2p connection between two nodes using QUIC only takes a single RTT." />}}
 
 Following the multiaddress format, a standard QUIC connection will
-look like: `/ip4/127.0.0.1/udp/65432/quicv1/`.
+look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
 
 ### QUIC v0
 
@@ -104,7 +104,7 @@ The initial implementation of QUIC for some implementations (e.g. go-libp2p),
 "QUIC v0", was based on
 [draft-ietf-quic-transport-29](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-29)
 (or simply, **draft-29**) by the IETF as [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000)
-was yet to be deployed. Many nodes still use draft-29 as their deployed version. A codepoint, `quicv1`,
+was yet to be finalized. Many nodes still use draft-29 as their deployed version. A codepoint, `quicv1`,
 is used to distinguish between the two versions.
 
 A standard QUIC connection will look like: `/ip4/127.0.0.1/udp/65432/quicv1/`, whereas the initial
@@ -113,7 +113,6 @@ codepoint, `quic` (e.g. `/ip4/127.0.0.1/udp/65432/quic/`) defaults to draft-29.
 Nodes that support multiple versions can offer them on the same port.
 Since QUIC packets contain the version number and any (multi-version)
 QUIC stack will be able to handle packets from different QUIC versions,
-demultiplexing works as intended.
 
 Due to version negotiation, a 1 RTT penalty will incur when connecting a QUIC v1 node to a
 legacy node.


### PR DESCRIPTION
## Context

- Adds a section under "QUIC in libp2p" to outline the new codepoint for QUIC v1, `quicv1`.
- resolves #230

## Latest preview

Please view the latest Fleek preview [here](https://bafybeienh5ijfzmck6omwrrtincdyk4flhwdsh4xqrdov4v62p642wu3l4.on.fleek.co/concepts/transports/quic/#quic-code-point).