### PR TITLE
update: aliases param to false

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,6 @@
 baseurl = "/"
 canonifyURLs = false
-disableAliases = true
+disableAliases = false
 disableHugoGeneratorInject = true
 enableEmoji = true
 enableGitInfo = false


### PR DESCRIPTION
## Context

Noticed that the aliases were't working. Seems like the update to `disableAliases` wasn't captured or accidentally changed back to true.

## Preview

Example: https://bafybeibnhuacz3x4slidrdjnpmu5ulbvdzoz3z3xoov47mdvq45xgruyny.on.fleek.co/concepts/publish-subscribe/  maps correctly to 
https://bafybeibnhuacz3x4slidrdjnpmu5ulbvdzoz3z3xoov47mdvq45xgruyny.on.fleek.co/concepts/pubsub/overview/