### PR TITLE
add: populate secure comm overview

### DIFF
--- a/content/concepts/secure-comm/overview.md
+++ b/content/concepts/secure-comm/overview.md
@@ -8,8 +8,26 @@ aliases:
 
 ## Overview
 
-Before two peers can transmit data, the communication channel they established
-with a transport protocol should be secure. A transport protocol like QUIC provides
-security guarantees out-of-the-box, but other transports in libp2p do not provide
-the logic to secure their channel. This requires an upgrade to the transport using an
-upgrader. Security is always established first over the raw connection.
+Before two peers can transmit data, the communication channel they
+establish with a transport protocol should be secure. By design,
+LibP2P promotes modularity, meaning that different types of transports
+can be used as part of the networking stack to power communication across
+system or application. Some transports can include native channel encryption,
+like QUIC, while other transports that establish a raw connection, like TCP
+sockets, lack native security and require a channel upgrade.
+
+## Secure channels in LibP2P
+
+A channel is upgraded with a component that layers security (and
+[stream multiplexing](../multiplex/overview)) over "raw" connections, known
+as a transport upgrader. A transport upgrader uses a protocol called **multistream-select**
+to negotiate the security and multiplexing protocols to use between two peers. Security
+is always established first over the "raw" connection. More information on **multistream-select**
+is available
+[here](https://github.com/libp2p/specs/blob/master/connections/README.md#multistream-select).
+LibP2P supports two security protocols, both with the technical
+specifications: [Noise](https://github.com/libp2p/specs/blob/master/noise/README.md)
+and [TLS 1.3](https://github.com/libp2p/specs/blob/master/tls/tls.md).
+
+Get introduced to TLS 1.3 by viewing the [TLS document](tls).
+Get introduced to Noise by viewing the [Noise document](noise).

--- a/content/concepts/secure-comm/overview.md
+++ b/content/concepts/secure-comm/overview.md
@@ -11,13 +11,13 @@ aliases:
 Before two peers can transmit data, the communication channel they
 establish needs to be secured. By design,
 libp2p supports many different transports (TCP, QUIC, WebSocket, WebTransport,
-etc.). Some transports have built-in encryption at the transport layer (e.g. QUIC)
+etc.). Some transports have built-in encryption at the transport layer
 like [QUIC](../transports/quic), while other transports (e.g. TCP, WebSocket)
-lack native security and require a security handshake after the connection has been
+lack native security and require a security handshake after the transport connection has been
 established.
 
 ## Secure channels in libp2p
 
-Libp2p supports two security protocols, [TLS 1.3](tls) and [Noise](noise).
+libp2p specifies two security protocols, [TLS 1.3](tls) and [Noise](noise).
 After the handshake has finished, we need to negotiate a
 [stream multiplexer](../multiplex/overview) for the connection.

--- a/content/concepts/secure-comm/overview.md
+++ b/content/concepts/secure-comm/overview.md
@@ -10,24 +10,20 @@ aliases:
 
 Before two peers can transmit data, the communication channel they
 establish with a transport protocol should be secure. By design,
-LibP2P promotes modularity, meaning that different types of transports
+libp2p promotes modularity, meaning that different types of transports
 can be used as part of the networking stack to power communication across
-system or application. Some transports can include native channel encryption,
-like QUIC, while other transports that establish a raw connection, like TCP
-sockets, lack native security and require a channel upgrade.
+system or application. Some transports include native channel encryption,
+like [QUIC](../transports/quic), while other transports that establish a
+raw connection, like TCP sockets, lack native security and require a channel
+upgrade.
 
-## Secure channels in LibP2P
+## Secure channels in libp2p
 
 A channel is upgraded with a component that layers security (and
 [stream multiplexing](../multiplex/overview)) over "raw" connections, known
-as a transport upgrader. A transport upgrader uses a protocol called **multistream-select**
-to negotiate the security and multiplexing protocols to use between two peers. Security
-is always established first over the "raw" connection. More information on **multistream-select**
-is available
+as a transport upgrader. In libp2p, a transport upgrader uses a protocol
+called **multistream-select** to negotiate the security and multiplexing protocols
+to use between two peers. Security is always established first over the "raw"
+connection. More information on **multistream-select** is available
 [here](https://github.com/libp2p/specs/blob/master/connections/README.md#multistream-select).
-LibP2P supports two security protocols, both with the technical
-specifications: [Noise](https://github.com/libp2p/specs/blob/master/noise/README.md)
-and [TLS 1.3](https://github.com/libp2p/specs/blob/master/tls/tls.md).
-
-Get introduced to TLS 1.3 by viewing the [TLS document](tls).
-Get introduced to Noise by viewing the [Noise document](noise).
+Libp2p supports two security protocols, [TLS 1.3](tls) and [Noise](noise).

--- a/content/concepts/secure-comm/overview.md
+++ b/content/concepts/secure-comm/overview.md
@@ -10,18 +10,14 @@ aliases:
 
 Before two peers can transmit data, the communication channel they
 establish needs to be secured. By design,
-libp2p supports many different transports (TCP, QUIC, WebSocket, WebTransport, etc.).
-Some transports have built-in encryption at the transport layer (e.g. QUIC)
-like [QUIC](../transports/quic), while other transports (e.g. TCP, WebSocket) lack native security 
-and require a security handshake after the connection has been established.
+libp2p supports many different transports (TCP, QUIC, WebSocket, WebTransport,
+etc.). Some transports have built-in encryption at the transport layer (e.g. QUIC)
+like [QUIC](../transports/quic), while other transports (e.g. TCP, WebSocket)
+lack native security and require a security handshake after the connection has been
+established.
 
 ## Secure channels in libp2p
 
-A channel is upgraded with a component that layers security (and
-[stream multiplexing](../multiplex/overview)) over "raw" connections, known
-as a transport upgrader. In libp2p, a transport upgrader uses a protocol
-called **multistream-select** to negotiate the security and multiplexing protocols
-to use between two peers. Security is always established first over the "raw"
-connection. More information on **multistream-select** is available
-[here](https://github.com/libp2p/specs/blob/master/connections/README.md#multistream-select).
 Libp2p supports two security protocols, [TLS 1.3](tls) and [Noise](noise).
+After the handshake has finished, we need to negotiate a
+[stream multiplexer](../multiplex/overview) for the connection.

--- a/content/concepts/secure-comm/overview.md
+++ b/content/concepts/secure-comm/overview.md
@@ -9,13 +9,11 @@ aliases:
 ## Overview
 
 Before two peers can transmit data, the communication channel they
-establish with a transport protocol should be secure. By design,
-libp2p promotes modularity, meaning that different types of transports
-can be used as part of the networking stack to power communication across
-system or application. Some transports include native channel encryption,
-like [QUIC](../transports/quic), while other transports that establish a
-raw connection, like TCP sockets, lack native security and require a channel
-upgrade.
+establish needs to be secured. By design,
+libp2p supports many different transports (TCP, QUIC, WebSocket, WebTransport, etc.).
+Some transports have built-in encryption at the transport layer (e.g. QUIC)
+like [QUIC](../transports/quic), while other transports (e.g. TCP, WebSocket) lack native security 
+and require a security handshake after the connection has been established.
 
 ## Secure channels in libp2p
 


### PR DESCRIPTION
## Context

- Adds overview for secure communication 
- Part of https://github.com/libp2p/docs/issues/19

### Notes

Section this document lives under will become populated with corresponding PRs.

## Latest preview

Please view the latest Fleek preview [here](https://bafybeie4vcl5j5hgmg4ejsp5eqkdrzkhw4cdtu7x4w3zbszhylrndabbfm.on.fleek.co/concepts/secure-comm/overview/).