### PR TITLE
Add link to Nim tutorials

### DIFF
--- a/content/guides/getting-started/nim.md
+++ b/content/guides/getting-started/nim.md
@@ -1,0 +1,10 @@
+---
+title: "Run a nim-libp2p node"
+weight: 5
+description: "Learn how to run use nim-libp2p"
+aliases:
+    - "/tutorials/nim"
+    - "/guides/nim"
+---
+
+Check out [tutorials of the Nim libp2p implementation](https://status-im.github.io/nim-libp2p/docs/).


### PR DESCRIPTION
Like Rust, our tutorials are kept up to date & ran in our CI, so it's easier to just link them.