### PR TITLE
feat: early muxer negotiation

### DIFF
--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -1,19 +1,18 @@
 ---
 title: "Early Multiplexer Negotiation"
-description: "Peers can use security protocol extenstions for early muxer negotiation."
+description: "Early stream multiplexer negotiation is an optimization in libp2p where peers can negotiate which multiplexer to use during the security protocol handshake, saving one round trip."
 weight: 162
 ---
 
-## Typical connection upgrade process
+## Vanilla stream multiplexer selection process
 
 Peers upgrade raw transport connections by using the same
 [multistream-selection](https://github.com/multiformats/multistream-select)
 protocol to negotiate security and stream multiplexing.
 
-First, security is established, and a security handshake is performed
-either for [Noise](../secure-comm/noise) or [TLS 1.3](../secure-comm/tls).
-Multistream-select will run again on top of
-the secure channel to negotiate a steam muxer, like [yamux](yamux).
+First, the security protocol is negotiated, then this protocol is used to perform a cryptographic handshake. libp2p currently supports [Noise](../secure-comm/noise) and [TLS 1.3](../secure-comm/tls).
+Once the cryptographic handshake completes, multistream-select runs again on top of
+the secured connection to negotiate a steam multiplexer, like [yamux](yamux) or [mplex](mplex).
 
 <!-- ADD DIAGRAM -->
 
@@ -36,9 +35,7 @@ upgrading a raw connection.
 
 ### Extension registry in Noise
 
-Similar to ALPN, Noise in libp2p introduces an extension registry that includes a collection of defined extensions used
-to extend the functionality of Noise. This has additional features and capabilities during the Noise handshake, including
-negotiating a stream muxer.
+Since there's no commonly used extension mechanism in Noise, libp2p defines an extension registry. We then defined an extension to negotiate the stream multiplexer, that is conceptually the equivalent of the ALPN extension in TLS.
 
 > The extension registry is modeled after
 > [RFC 6066](https://www.rfc-editor.org/rfc/rfc6066) (for TLS) and

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -7,15 +7,21 @@ weight: 162
 ## Vanilla stream multiplexer selection process
 
 One of libp2p's main guarantees is that no data sent over the wire is unencrypted.
-This means that transport protocols, like TCP or WebSocket, that don't support encryption by default must complete a cryptographic handshake.
-This process of adding the secure channel on top of the raw transport is called upgrading the connections and happens via the [multistream-select protocol](https://github.com/multiformats/multistream-select).
+This means that transport protocols, like TCP or WebSocket, that don't support encryption
+by default must complete a cryptographic handshake. This process of adding the secure channel
+on top of the raw transport is called upgrading the connections and happens via the
+[multistream-select protocol](https://github.com/multiformats/multistream-select).
 
-In the unoptimized libp2p connection upgrade process, the security or encryption is negotiated first.
-After that is agreed upon, the stream multiplexer is negotiated. Again this only happens for transports that don't have native stream multiplexing.
+In the unoptimized libp2p connection upgrade process, the security or encryption is negotiated
+first. After that is agreed upon, the stream multiplexer is negotiated. Again this only happens
+for transports that don't have native stream multiplexing.
 
-A standard connection upgrade process that negotiates the secure channel first and the multiplexer second [is shown in a diagram here](https://github.com/libp2p/specs/tree/master/connections#upgrading-connections).
+A standard connection upgrade process that negotiates the secure channel first and the multiplexer
+second
+[is shown in a diagram here](https://github.com/libp2p/specs/tree/master/connections#upgrading-connections).
 
-First, the security protocol is negotiated, then this protocol is used to perform a cryptographic handshake. libp2p currently supports [Noise](../secure-comm/noise) and [TLS 1.3](../secure-comm/tls).
+First, the security protocol is negotiated, then this protocol is used to perform a cryptographic
+handshake. libp2p currently supports [Noise](../secure-comm/noise) and [TLS 1.3](../secure-comm/tls).
 Once the cryptographic handshake completes, multistream-select runs again on top of
 the secured connection to negotiate a steam multiplexer, like [yamux](yamux) or [mplex](mplex).
 
@@ -23,24 +29,34 @@ the secured connection to negotiate a steam multiplexer, like [yamux](yamux) or 
 
 ## Early muxer negotiation
 
-The libp2p project eliminates an unnecessary round trip in the standard negotiation protocol for selecting a stream multiplexer. This is achieved by combining the steps of agreeing on a secure channel and multiplexer. This is called "early" or "inlined" muxer negotiation.
-Early muxer negotiation is a feature in libp2p that allows for the simultaneous selection of a stream multiplexer during the cryptographic handshake of the TLS and Noise security protocols. This is achieved by sharing a list of supported muxer protocols as a part of the handshake payload. 
+The libp2p project eliminates an unnecessary round trip in the standard negotiation protocol
+for selecting a stream multiplexer. This is achieved by combining the steps of agreeing on a
+secure channel and multiplexer. This is called "early" or "inlined" muxer negotiation.
 
-For example, if a libp2p node supports mplex and yamux, it will advertise both in the list. This eliminates an extra round trip, improving TTFB (time to first byte) in the libp2p handshake. Currently, this feature is only supported in go-libp2p and for TCP and WebSocket transports that do not have native encryption or multiplexing.
+Early muxer negotiation is a feature in libp2p that allows for the simultaneous selection of a
+stream multiplexer during the cryptographic handshake of the TLS and Noise security protocols.
+This is achieved by sharing a list of supported muxer protocols as a part of the handshake payload.
+
+For example, if a libp2p node supports mplex and yamux, it will advertise both in the list.
+This **eliminates an extra round trip**, improving TTFB (time to first byte) in the libp2p handshake.
+Currently, this feature is only supported in go-libp2p and for TCP and WebSocket transports that do
+not have native encryption or multiplexing.
 
 <!-- ADD DIAGRAM -->
 
 ### ALPN extension in TLS
 
-The [Application-Layer Protocol Negotiation (ALPN) extension](https://datatracker.ietf.org/doc/html/rfc7301) is a feature of
-TLS that allows for the negotiation of application-layer protocols during the TLS handshake. This allows the client and server
-to agree on the application-layer protocol for the rest of the TLS session. ALPN is typically used to negotiate the application-layer protocol
-for applications that use TLS, such as HTTP/2 or QUIC. libp2p uses ALPN to negotiate the stream muxer and saves a roundtrip when
-upgrading a raw connection.
+The [Application-Layer Protocol Negotiation (ALPN) extension](https://datatracker.ietf.org/doc/html/rfc7301)
+is a feature of TLS that allows for the negotiation of application-layer protocols during the TLS handshake.
+This allows the client and server to agree on the application-layer protocol for the rest of the TLS session.
+ALPN is typically used to negotiate the application-layer protocol for applications that use TLS, such as HTTP/2
+or QUIC. libp2p uses ALPN to negotiate the stream muxer and saves a roundtrip when upgrading a raw connection.
 
 ### Extension registry in Noise
 
-Since there's no commonly used extension mechanism in Noise, libp2p defines an extension registry. We then defined an extension to negotiate the stream multiplexer, that is conceptually the equivalent of the ALPN extension in TLS.
+Since there's no commonly used extension mechanism in Noise, libp2p defines an extension registry.
+We then defined an extension to negotiate the stream multiplexer, that is conceptually the equivalent
+of the ALPN extension in TLS.
 
 > The extension registry is modeled after
 > [RFC 6066](https://www.rfc-editor.org/rfc/rfc6066) (for TLS) and

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -6,11 +6,13 @@ weight: 162
 
 ## Typical connection upgrade process
 
-Once peers establish a raw connection, they can upgrade their connection by running the
+Peers upgrade raw transport connections by using the same
 [multistream-selection](https://github.com/multiformats/multistream-select)
-protocol. To do so, the dialing and listening peers use the same multistream-select protocol to negotiate the security
-protocol that creates a secure channel over the raw connection, where the security protocol handshake is performed,
-either for [Noise](../secure-comm/noise) or [TLS 1.3](../secure-comm/tls). Multistream-select will run again on top of
+protocol to negotiate security and stream multiplexing.
+
+First, security is established, and a security handshake is performed
+either for [Noise](../secure-comm/noise) or [TLS 1.3](../secure-comm/tls).
+Multistream-select will run again on top of
 the secure channel to negotiate a steam muxer, like [yamux](yamux).
 
 <!-- ADD DIAGRAM -->
@@ -20,22 +22,21 @@ the secure channel to negotiate a steam muxer, like [yamux](yamux).
 Early muxer negotiation is possible through the handshake of security protocols being able to negotiate higher-level
 protocols. The early negotiation takes place as a list of supported stream muxers is shared during the security protocol
 handshake, and a security protocol extension handles the stream muxer negotiation while it negotiates the secure channel
-establishment. This saves 1 RTT during the libp2p handshake, and, as a result, reduces the TTFB (time to first byte).
+establishment. This saves 1 RTT during the libp2p handshake and, as a result, reduces the TTFB (time to first byte).
 
 <!-- ADD DIAGRAM -->
 
 ### ALPN extension in TLS
 
 The [Application-Layer Protocol Negotiation (ALPN) extension](https://datatracker.ietf.org/doc/html/rfc7301) is a feature of
-TLS allows for the negotiation of application-layer protocols during the TLS handshake. This allows the client and server
-to agree on the application-layer protocol for the rest of the TLS session, enabling them to communicate using a standard
-protocol and ensuring that the client and server are compatible. ALPN is typically used to negotiate the application-layer protocol
-for applications that use TLS, such as HTTP/2 or QUIC. Libp2p uses ALPN to negotiate the stream muxer and saves a roundtrip when
+TLS that allows for the negotiation of application-layer protocols during the TLS handshake. This allows the client and server
+to agree on the application-layer protocol for the rest of the TLS session. ALPN is typically used to negotiate the application-layer protocol
+for applications that use TLS, such as HTTP/2 or QUIC. libp2p uses ALPN to negotiate the stream muxer and saves a roundtrip when
 upgrading a raw connection.
 
 ### Extension registry in Noise
 
-Similar to ALPN, Noise in libp2p includes an extension registry which includes a collection of defined extensions that can be used
+Similar to ALPN, Noise in libp2p introduces an extension registry that includes a collection of defined extensions used
 to extend the functionality of Noise. This has additional features and capabilities during the Noise handshake, including
 negotiating a stream muxer.
 

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -1,0 +1,47 @@
+---
+title: "Early Multiplexer Negotiation"
+description: "Peers can use security protocol extenstions for early muxer negotiation."
+weight: 162
+---
+
+## Typical connection upgrade process
+
+Once peers establish a raw connection, they can upgrade their connection by running the multistream-selection
+protocol. To do so, the dialing and listening peers use the same multistream-select protocol to negotiate the security
+protocol that creates a secure channel over the raw connection, and the security protocol handshake is performed,
+either [Noise](../secure-comm/noise) or [TLS 1.3](../secure-comm/tls). Multistream-select will run again on top of the
+secure channel to negotiate a steam muxer, like [yamux](yamux).
+
+<!-- ADD DIAGRAM -->
+
+## Early muxer negotiation
+
+Early muxer negotiation is possible through the handshake of security protocols being able to negotiate higher-level
+protocols. The early negotiation takes place as a list of supported stream muxers is shared during the security protocol
+handshake, and a security protocol extension handles the stream muxer negotiation while it negotiates the secure channel
+establishment. This saves 1 RTT during the libp2p handshake.
+
+<!-- ADD DIAGRAM -->
+
+### ALPN extension in TLS
+
+The [Application-Layer Protocol Negotiation (ALPN) extension](https://datatracker.ietf.org/doc/html/rfc7301) is a feature of
+TLS allows for the negotiation of application-layer protocols during the TLS handshake. This allows the client and server
+to agree on the application-layer protocol for the rest of the TLS session, enabling them to communicate using a standard
+protocol and ensuring that the client and server are compatible. ALPN is typically used to negotiate the application-layer protocol
+for applications that use TLS, such as HTTP/2 or QUIC. Libp2p uses ALPN to negotiate the stream muxer and saves a roundtrip when
+upgrading a raw connection.
+
+### Extension registry in Noise
+
+Similar to ALPN, Noise in libp2p includes an extension registry which includes a collection of defined extensions that can be used
+to extend the functionality of Noise. This has additional features and capabilities during the Noise handshake, including
+negotiating a stream muxer.
+
+> The extension registry is modeled after
+> [RFC 6066](https://www.rfc-editor.org/rfc/rfc6066) (for TLS) and
+> [RFC 9000](https://datatracker.ietf.org/doc/html/rfc9000#section-19.21)
+> (for QUIC).
+
+More information is available in the
+[Noise specification](https://github.com/libp2p/specs/blob/master/noise/README.md#libp2p-data-in-handshake-messages).

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -6,9 +6,14 @@ weight: 162
 
 ## Vanilla stream multiplexer selection process
 
-Peers upgrade raw transport connections by using the same
-[multistream-selection](https://github.com/multiformats/multistream-select)
-protocol to negotiate security and stream multiplexing.
+One of libp2p's main guarantees is that no data sent over the wire is unencrypted.
+This means that transport protocols, like TCP or WebSocket, that don't support encryption by default must complete a cryptographic handshake.
+This process of adding the secure channel on top of the raw transport is called upgrading the connections and happens via the [multistream-select protocol](https://github.com/multiformats/multistream-select).
+
+In the unoptimized libp2p connection upgrade process, the security or encryption is negotiated first.
+After that is agreed upon, the stream multiplexer is negotiated. Again this only happens for transports that don't have native stream multiplexing.
+
+A standard connection upgrade process that negotiates the secure channel first and the multiplexer second [is shown in a diagram here](https://github.com/libp2p/specs/tree/master/connections#upgrading-connections).
 
 First, the security protocol is negotiated, then this protocol is used to perform a cryptographic handshake. libp2p currently supports [Noise](../secure-comm/noise) and [TLS 1.3](../secure-comm/tls).
 Once the cryptographic handshake completes, multistream-select runs again on top of
@@ -18,10 +23,10 @@ the secured connection to negotiate a steam multiplexer, like [yamux](yamux) or 
 
 ## Early muxer negotiation
 
-Early muxer negotiation is possible through the handshake of security protocols being able to negotiate higher-level
-protocols. The early negotiation takes place as a list of supported stream muxers is shared during the security protocol
-handshake, and a security protocol extension handles the stream muxer negotiation while it negotiates the secure channel
-establishment. This saves 1 RTT during the libp2p handshake and, as a result, reduces the TTFB (time to first byte).
+The libp2p project eliminates an unnecessary round trip in the standard negotiation protocol for selecting a stream multiplexer. This is achieved by combining the steps of agreeing on a secure channel and multiplexer. This is called "early" or "inlined" muxer negotiation.
+Early muxer negotiation is a feature in libp2p that allows for the simultaneous selection of a stream multiplexer during the cryptographic handshake of the TLS and Noise security protocols. This is achieved by sharing a list of supported muxer protocols as a part of the handshake payload. 
+
+For example, if a libp2p node supports mplex and yamux, it will advertise both in the list. This eliminates an extra round trip, improving TTFB (time to first byte) in the libp2p handshake. Currently, this feature is only supported in go-libp2p and for TCP and WebSocket transports that do not have native encryption or multiplexing.
 
 <!-- ADD DIAGRAM -->
 
@@ -44,3 +49,5 @@ Since there's no commonly used extension mechanism in Noise, libp2p defines an e
 
 More information is available in the
 [Noise specification](https://github.com/libp2p/specs/blob/master/noise/README.md#libp2p-data-in-handshake-messages).
+
+{{< alert icon="💡" context="note" text="See the inclined muxer negotiation<a class=\"text-muted\" href=\"https://github.com/libp2p/specs/blob/master/connections/inlined-muxer-negotiation.md">specification</a> for more details." />}}

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -66,4 +66,4 @@ of the ALPN extension in TLS.
 More information is available in the
 [Noise specification](https://github.com/libp2p/specs/blob/master/noise/README.md#libp2p-data-in-handshake-messages).
 
-{{< alert icon="💡" context="note" text="See the inclined muxer negotiation<a class=\"text-muted\" href=\"https://github.com/libp2p/specs/blob/master/connections/inlined-muxer-negotiation.md">specification</a> for more details." />}}
+{{< alert icon="💡" context="note" text="See the inclined muxer negotiation <a class=\"text-muted\" href=\"https://github.com/libp2p/specs/blob/master/connections/inlined-muxer-negotiation.md\">specification</a> for more details." />}}

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -6,11 +6,12 @@ weight: 162
 
 ## Typical connection upgrade process
 
-Once peers establish a raw connection, they can upgrade their connection by running the multistream-selection
+Once peers establish a raw connection, they can upgrade their connection by running the
+[multistream-selection](https://github.com/multiformats/multistream-select)
 protocol. To do so, the dialing and listening peers use the same multistream-select protocol to negotiate the security
-protocol that creates a secure channel over the raw connection, and the security protocol handshake is performed,
-either [Noise](../secure-comm/noise) or [TLS 1.3](../secure-comm/tls). Multistream-select will run again on top of the
-secure channel to negotiate a steam muxer, like [yamux](yamux).
+protocol that creates a secure channel over the raw connection, where the security protocol handshake is performed,
+either for [Noise](../secure-comm/noise) or [TLS 1.3](../secure-comm/tls). Multistream-select will run again on top of
+the secure channel to negotiate a steam muxer, like [yamux](yamux).
 
 <!-- ADD DIAGRAM -->
 
@@ -19,7 +20,7 @@ secure channel to negotiate a steam muxer, like [yamux](yamux).
 Early muxer negotiation is possible through the handshake of security protocols being able to negotiate higher-level
 protocols. The early negotiation takes place as a list of supported stream muxers is shared during the security protocol
 handshake, and a security protocol extension handles the stream muxer negotiation while it negotiates the secure channel
-establishment. This saves 1 RTT during the libp2p handshake.
+establishment. This saves 1 RTT during the libp2p handshake, and, as a result, reduces the TTFB (time to first byte).
 
 <!-- ADD DIAGRAM -->
 


### PR DESCRIPTION
## Context

- Adds content for early muxer negotiation
> Not sure where the best place for this would be with the current structure. It is a new document under the general "multiplexer" section.
- Future diagrams would be key for this document.
- resolves #213, part of #212

Latest preview

Please view the latest Fleek preview [here](https://bafybeid45iq72jql7n2cvlcfz4r4oq3zuar3ier2hj4fsucia2umoyfxl4.on.fleek.co/concepts/multiplex/early-negotiation/).