### PR TITLE
update(docs): non-test-net addresses -> special-purpose addresses for docs

### DIFF
--- a/content/concepts/appendix/glossary.md
+++ b/content/concepts/appendix/glossary.md
@@ -57,7 +57,7 @@ The process of accepting incoming libp2p connections is known as "listening", an
 
 A `multiaddress` (often abbreviated `multiaddr`), is a convention for encoding multiple layers of addressing information into a single "future-proof" path structure.
 
-For example: `/ip4/127.0.0.1/udp/1234` encodes two protocols along with their essential addressing information. The `/ip4/127.0.0.1` informs us that we want the `127.0.0.1` loopback address of the IPv4 protocol, and `/udp/1234` tells us we want to send UDP packets to port `1234`.
+For example: `/ip4/192.0.2.0/udp/1234` encodes two protocols along with their essential addressing information. The `/ip4/192.0.2.0` informs us that we want the `192.0.2.0` loopback address of the IPv4 protocol, and `/udp/1234` tells us we want to send UDP packets to port `1234`.
 
 Multiaddresses can be composed to describe multiple "layers" of addresses.
 

--- a/content/concepts/fundamentals/addressing.md
+++ b/content/concepts/fundamentals/addressing.md
@@ -12,7 +12,7 @@ we need a way to work with a lot of different addressing schemes in a consistent
 
 A `multiaddress` (often abbreviated `multiaddr`), is a convention for encoding multiple layers of addressing information into a single "future-proof" path structure. It [defines][spec_multiaddr] human-readable and machine-optimized encodings of common transport and overlay protocols and allows many layers of addressing to be combined and used together.
 
-For example: `/ip4/127.0.0.1/udp/1234` encodes two protocols along with their essential addressing information. The `/ip4/127.0.0.1` informs us that we want the `127.0.0.1` loopback address of the IPv4 protocol, and `/udp/1234` tells us we want to send UDP packets to port `1234`.
+For example: `/ip4/192.0.2.0/udp/1234` encodes two protocols along with their essential addressing information. The `/ip4/192.0.2.0` informs us that we want the `192.0.2.0` loopback address of the IPv4 protocol, and `/udp/1234` tells us we want to send UDP packets to port `1234`.
 
 Things get more interesting as we compose further. For example, the multiaddr `/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N` uniquely identifies my local IPFS node, using libp2p's [registered protocol id](https://github.com/multiformats/multiaddr/blob/master/protocols.csv) `/p2p/` and the [multihash](/reference/glossary/#multihash) of my IPFS node's public key.
 
@@ -20,16 +20,16 @@ Things get more interesting as we compose further. For example, the multiaddr `/
 For more on peer identity and its relation to public key cryptography, see [Peer Identity](../peers/#peer-id/).
 {{< /alert >}}
 
-Let's say that I have the Peer ID `QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N` as above, and my public ip is `7.7.7.7`. I start my libp2p application and listen for connections on TCP port `4242`.
+Let's say that I have the Peer ID `QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N` as above, and my public ip is `198.51.100.0`. I start my libp2p application and listen for connections on TCP port `4242`.
 
-Now I can start [handing out multiaddrs to all my friends](/concepts/peer-routing/), of the form `/ip4/7.7.7.7/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N`. Combining my "location multiaddr" (my IP and port) with my "identity multiaddr" (my libp2p `PeerId`), produces a new multiaddr containing both key pieces of information.
+Now I can start [handing out multiaddrs to all my friends](/concepts/peer-routing/), of the form `/ip4/198.51.100.0/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N`. Combining my "location multiaddr" (my IP and port) with my "identity multiaddr" (my libp2p `PeerId`), produces a new multiaddr containing both key pieces of information.
 
 Now not only do my friends know where to find me, anyone they give that address to can verify that the machine on the other side is really me, or at least, that they control the private key for my `PeerId`. They also know (by virtue of the `/p2p/` protocol id) that I'm likely to support common libp2p interactions like opening connections and negotiating what application protocols we can use to communicate. That's not bad!
 
 This can be extended to account for multiple layers of addressing and abstraction. For example, the [addresses used for circuit relay](/concepts/circuit-relay/#relay-addresses) combine transport addresses with multiple peer identities to form an address that describes a "relay circuit":
 
 ```shell
-/ip4/7.7.7.7/tcp/4242/p2p/QmRelay/p2p-circuit/p2p/QmRelayedPeer
+/ip4/198.51.100.0/tcp/4242/p2p/QmRelay/p2p-circuit/p2p/QmRelayedPeer
 ```
 
 ### More information

--- a/content/concepts/fundamentals/peers.md
+++ b/content/concepts/fundamentals/peers.md
@@ -67,10 +67,10 @@ libp2p multiaddress for me would be:
 As with other multiaddrs, a `/p2p` address can be encapsulated into
 another multiaddr to compose into a new multiaddr. For example, I can combine
 the above with a [transport](/concepts/transport/) address
-`/ip4/7.7.7.7/tcp/4242` to produce this very useful address:
+`/ip4/198.51.100.0/tcp/4242` to produce this very useful address:
 
 ```shell
-/ip4/7.7.7.7/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N
+/ip4/198.51.100.0/tcp/4242/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N
 ```
 
 This provides enough information to dial a specific peer over a TCP/IP

--- a/content/concepts/nat/circuit-relay.md
+++ b/content/concepts/nat/circuit-relay.md
@@ -42,9 +42,9 @@ The address above is interesting, because it doesn't include any [transport](../
 
 A better address would be something like `/p2p/QmRelay/p2p-circuit/p2p/QmAlice`. This includes the identity of a specific relay peer, `QmRelay`. If a peer already knows how to open a connection to `QmRelay`, they'll be able to reach us.
 
-Better still is to include the transport addresses for the relay peer in the address. Let's say that I've established a connection to a specific relay with the Peer ID `QmRelay`. They told me via the identify protocol that they're listening for TCP connections on port `55555` at IPv4 address `7.7.7.7`. I can construct an address that describes a path to me through that specific relay over that transport:
+Better still is to include the transport addresses for the relay peer in the address. Let's say that I've established a connection to a specific relay with the Peer ID `QmRelay`. They told me via the identify protocol that they're listening for TCP connections on port `55555` at IPv4 address `198.51.100.0`. I can construct an address that describes a path to me through that specific relay over that transport:
 
-`/ip4/7.7.7.7/tcp/55555/p2p/QmRelay/p2p-circuit/p2p/QmAlice`
+`/ip4/198.51.100.0/tcp/55555/p2p/QmRelay/p2p-circuit/p2p/QmAlice`
 
 Everything prior to the `/p2p-circuit/` above is the address of the relay peer, which includes the transport address and their Peer ID `QmRelay`. After `/p2p-circuit/` is the Peer ID for my peer at the other end of the line, `QmAlice`.
 

--- a/content/concepts/security/dos-mitigation.md
+++ b/content/concepts/security/dos-mitigation.md
@@ -287,7 +287,7 @@ ip address of the peer from the
 [multiaddr](https://github.com/multiformats/multiaddr) in the log.
 
 ```bash
-sudo ufw deny from 1.2.3.4
+sudo ufw deny from 192.0.2.0
 ```
 
 ### How to automate blocking with fail2ban

--- a/content/concepts/transports/listen-and-dial.md
+++ b/content/concepts/transports/listen-and-dial.md
@@ -35,12 +35,12 @@ interfaces.
 Here's an example of a multiaddr for a TCP/IP transport:
 
 ```shell
-/ip4/7.7.7.7/tcp/6543
+/ip4/198.51.100.0/tcp/6543
 ```
 
-This is equivalent to the more familiar `7.7.7.7:6543` construction, but it
+This is equivalent to the more familiar `198.51.100.0:6543` construction, but it
 has the advantage of being explicit about the protocols that are being
-described. With the multiaddr, you can see at a glance that the `7.7.7.7`
+described. With the multiaddr, you can see at a glance that the `198.51.100.0`
 address belongs to the IPv4 protocol, and the `6543` belongs to TCP.
 
 For more complex examples, see [addressing](../../fundamentals/addressing).
@@ -57,7 +57,7 @@ and prevents impersonation.
 An example multiaddress that includes a `PeerId`:
 
 ```shell
-/ip4/1.2.3.4/tcp/4321/p2p/QmcEPrat8ShnCph8WjkREzt5CPXF2RwhYxYBALDcLC1iV6
+/ip4/192.0.2.0/tcp/4321/p2p/QmcEPrat8ShnCph8WjkREzt5CPXF2RwhYxYBALDcLC1iV6
 ```
 
 The `/p2p/QmcEPrat8ShnCph8WjkREzt5CPXF2RwhYxYBALDcLC1iV6` component uniquely

--- a/content/concepts/transports/quic.md
+++ b/content/concepts/transports/quic.md
@@ -96,7 +96,7 @@ IDs are authenticated in the
 {{< alert icon="💡" context="note" text="To be clear, there is no additional security handshake and stream muxer needed as QUIC provides all of this by default. This also means that establishing a libp2p connection between two nodes using QUIC only takes a single RTT." />}}
 
 Following the multiaddress format, a standard QUIC connection will
-look like: `/ip4/127.0.0.1/udp/65432/quic-v1/`.
+look like: `/ip4/192.0.2.0/udp/65432/quic-v1/`.
 
 ### Distinguishing multiple QUIC versions in libp2p
 
@@ -110,7 +110,7 @@ However, the multiaddresses for these versions used the same format and thus wer
 By using different code points, `quic-v1` for RFC 9000 and `quic` for draft-29,
 libp2p can now distinguish between the two versions.
 
-The multiaddress for a QUIC listener accepting RFC 9000 connections looks like this: `/ip4/1.2.3.4/udp/65432/quic-v1/`, whereas the for the draft version, the multiaddress would be `/ip4/1.2.3.4/udp/65432/quic/`.
+The multiaddress for a QUIC listener accepting RFC 9000 connections looks like this: `/ip4/192.0.2.0/udp/65432/quic-v1/`, whereas the for the draft version, the multiaddress would be `/ip4/192.0.2.0/udp/65432/quic/`.
 
 Nodes that support multiple versions can offer them on the same port.
 QUIC long header packets contain the version number, which enables the QUIC stack to handle multiple versions.

--- a/content/concepts/transports/webtransport.md
+++ b/content/concepts/transports/webtransport.md
@@ -66,13 +66,13 @@ possible since the [browser API doesn't allow that yet](https://github.com/w3c/w
 WebTransport multiaddresses are composed of a QUIC multiaddr, followed
 by `/webtransport` and a list of multihashes of the node certificates that the server uses.
 
-For instance, for multiaddress `/ip4/127.0.0.1/udp/123/quic/webtransport/certhash/<hash1>`,
+For instance, for multiaddress `/ip4/192.0.2.0/udp/123/quic/webtransport/certhash/<hash1>`,
 a standard local QUIC connection is defined up until and including `/quic.`
 Then, `/webtransport/` runs over QUIC. The self-signed certificate hash that the
 server will use to verify the connection.
 
 The WebTransport CONNECT request is sent to an HTTPS endpoint. libp2p WebTransport server use
 `/.well-known/libp2p-webtransport`. For instance, the WebTransport URL of a WebTransport
-server advertising `/ip4/1.2.3.4/udp/1234/quic/webtransport/` would be
-`https://1.2.3.4:1234/.well-known/libp2p-webtransport?type=noise`
+server advertising `/ip4/192.0.2.0/udp/1234/quic/webtransport/` would be
+`https://192.0.2.0:1234/.well-known/libp2p-webtransport?type=noise`
 (the ?type=noise refers to the authentication scheme using Noise).

--- a/content/guides/getting-started/go.md
+++ b/content/guides/getting-started/go.md
@@ -100,7 +100,7 @@ We can now compile this into an executable using `go build` and run it from the 
 $ go build -o libp2p-node
 
 $ ./libp2p-node
-Listen addresses: [/ip6/::1/tcp/57666 /ip4/127.0.0.1/tcp/57665 /ip4/192.168.1.56/tcp/57665]
+Listen addresses: [/ip6/::1/tcp/57666 /ip4/192.0.2.0/tcp/57665 /ip4/198.51.100.0/tcp/57665]
 ```
 
 The listening addresses are formatted using the [multiaddr](https://github.com/multiformats/multiaddr)
@@ -120,7 +120,7 @@ func main() {
         // start a libp2p node that listens on TCP port 2000 on the IPv4
         // loopback interface
         node, err := libp2p.New(
-                libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/2000"),
+                libp2p.ListenAddrStrings("/ip4/192.0.2.0/tcp/2000"),
         )
     if err != nil {
         panic(err)
@@ -136,7 +136,7 @@ Re-building and running the executable again now prints the explicit listen addr
 $ go build -o libp2p-node
 
 $ ./libp2p-node
-Listening addresses: [/ip4/127.0.0.1/tcp/2000]
+Listening addresses: [/ip4/192.0.2.0/tcp/2000]
 ```
 
 `libp2p.New` accepts a variety of arguments to configure most aspects of the node. See
@@ -184,7 +184,7 @@ before shutting down:
 
 ```bash
 $ ./libp2p-node
-Listening addresses: [/ip4/127.0.0.1/tcp/2000]
+Listening addresses: [/ip4/192.0.2.0/tcp/2000]
 ^CReceived signal, shutting down...
 ```
 
@@ -225,7 +225,7 @@ func main() {
     // start a libp2p node that listens on a random local TCP port,
     // but without running the built-in ping protocol
     node, err := libp2p.New(
-        libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+        libp2p.ListenAddrStrings("/ip4/192.0.2.0/tcp/0"),
         libp2p.Ping(false),
     )
     if err != nil {
@@ -278,7 +278,7 @@ Running the node now prints the node's address that can be used to connect to it
 
 ```bash
 $ ./libp2p-node
-libp2p node address: /ip4/127.0.0.1/tcp/62268/ipfs/QmfQzWnLu4UX1cW7upgyuFLyuBXqze7nrPB4qWYqQiTHwt
+libp2p node address: /ip4/192.0.2.0/tcp/62268/ipfs/QmfQzWnLu4UX1cW7upgyuFLyuBXqze7nrPB4qWYqQiTHwt
 ```
 
 Let's also accept a command line argument that is the address of a peer to send ping messages to,
@@ -362,7 +362,7 @@ func main() {
     // start a libp2p node that listens on a random local TCP port,
     // but without running the built-in ping protocol
     node, err := libp2p.New(
-        libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+        libp2p.ListenAddrStrings("/ip4/192.0.2.0/tcp/0"),
         libp2p.Ping(false),
     )
     if err != nil {
@@ -423,21 +423,21 @@ In one terminal window, let's start a listening node (i.e. don't pass any comman
 
 ```bash
 $ ./libp2p-node
-libp2p node address: /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL
+libp2p node address: /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL
 ```
 
 In another terminal window, let's run a second node but pass the address of the first node, and we
 should see some ping responses logged:
 
 ```bash
-$ ./libp2p-node /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL
-libp2p node address: /ip4/127.0.0.1/tcp/61846/ipfs/QmVyKLTLswap3VYbpBATsgNpi6JdwSwsZALPxEnEbEndup
-sending 5 ping messages to /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL
-pinged /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 431.231µs
-pinged /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 164.94µs
-pinged /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 220.544µs
-pinged /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 208.761µs
-pinged /ip4/127.0.0.1/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 201.37µs
+$ ./libp2p-node /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL
+libp2p node address: /ip4/192.0.2.0/tcp/61846/ipfs/QmVyKLTLswap3VYbpBATsgNpi6JdwSwsZALPxEnEbEndup
+sending 5 ping messages to /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL
+pinged /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 431.231µs
+pinged /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 164.94µs
+pinged /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 220.544µs
+pinged /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 208.761µs
+pinged /ip4/192.0.2.0/tcp/61790/ipfs/QmZKjsGJ6ukXVRXVEcExx9GhiyWoJC97onYpzBwCHPWqpL in 201.37µs
 ```
 
 Success! Our two peers are now communicating using go-libp2p! Sure, they can only say “ping”, but it’s a start!

--- a/content/guides/getting-started/javascript.md
+++ b/content/guides/getting-started/javascript.md
@@ -143,7 +143,7 @@ const main = async () => {
   const node = await createLibp2p({
     addresses: {
       // add a listen address (localhost) to accept TCP connections on a random port
-      listen: ['/ip4/127.0.0.1/tcp/0']
+      listen: ['/ip4/192.0.2.0/tcp/0']
     },
     transports: [tcp()],
     connectionEncryption: [noise()],
@@ -174,7 +174,7 @@ Try running the code with `node src/index.js`. You should see something like:
 ```shell
 libp2p has started
 listening on addresses:
-/ip4/127.0.0.1/tcp/50626/p2p/QmYoqzFj5rhzFy7thCPPGbDkDkLMbQzanxCNwefZd3qTkz
+/ip4/192.0.2.0/tcp/50626/p2p/QmYoqzFj5rhzFy7thCPPGbDkDkLMbQzanxCNwefZd3qTkz
 libp2p has stopped
 ```
 
@@ -201,7 +201,7 @@ import { multiaddr } from 'multiaddr'
 const node = await createLibp2p({
   addresses: {
     // add a listen address (localhost) to accept TCP connections on a random port
-    listen: ['/ip4/127.0.0.1/tcp/0']
+    listen: ['/ip4/192.0.2.0/tcp/0']
   },
   transports: [tcp()],
   connectionEncryption: [noise()],
@@ -246,19 +246,19 @@ Now we can start one instance with no arguments:
 > node src/index.js
 libp2p has started
 listening on addresses:
-/ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
+/ip4/192.0.2.0/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
 no remote peer address given, skipping ping
 ```
 
 Grab the `/ip4/...` address printed above and use it as an argument to another instance.  In a new terminal:
 
 ```shell
-> node src/index.js /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
+> node src/index.js /ip4/192.0.2.0/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
 libp2p has started
 listening on addresses:
-/ip4/127.0.0.1/tcp/50777/p2p/QmYZirEPREz9vSRFznxhQbWNya2LXPz5VCahRCT7caTLGm
-pinging remote peer at /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
-pinged /ip4/127.0.0.1/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN in 3ms
+/ip4/192.0.2.0/tcp/50777/p2p/QmYZirEPREz9vSRFznxhQbWNya2LXPz5VCahRCT7caTLGm
+pinging remote peer at /ip4/192.0.2.0/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN
+pinged /ip4/192.0.2.0/tcp/50775/p2p/QmcafwJSsCsnjMo2fyf1doMjin8nrMawfwZiPftBDpahzN in 3ms
 libp2p has stopped
 ```
 


### PR DESCRIPTION
## Context

This change aims to update all the addresses across the docs to use the special-purposes addresses specified in [RFC 6890](https://datatracker.ietf.org/doc/rfc6890/).

  - 192.0.2.0/24 (TEST-NET-1)
  - 198.51.100.0/24 (TEST-NET-2)
  - 203.0.113.0/24 (TEST-NET-3)
