### PR TITLE
Repair dead links

### DIFF
--- a/content/concepts/contribute/community.md
+++ b/content/concepts/contribute/community.md
@@ -11,5 +11,5 @@ We love talking about libp2p, and we'd be happy to have you in the mix.
 
 Visit our [discussion forums](https://discuss.libp2p.io) to ask questions about [using libp2p](https://discuss.libp2p.io/c/users), discuss exciting [research](https://discuss.libp2p.io/c/research), and [stay up to date with important announcements](https://discuss.libp2p.io/c/news).
 
-We also often hang out on [Discord](https://discord.com/invite/ipfs) and in the #libp2p-implementers channel in the [Filecoin slack](filecoinproject.slack.com
+We also often hang out on [Discord](https://discord.com/invite/ipfs) and in the #libp2p-implementers channel in the [Filecoin slack](https://filecoinproject.slack.com
 ). While Discord is a great places for live chats, remember that discussions can get lost in a sea of messages. For long-lived discussion & support, [the discussion forums](https://discuss.libp2p.io) are the way to go.

--- a/content/concepts/contribute/community.md
+++ b/content/concepts/contribute/community.md
@@ -11,5 +11,4 @@ We love talking about libp2p, and we'd be happy to have you in the mix.
 
 Visit our [discussion forums](https://discuss.libp2p.io) to ask questions about [using libp2p](https://discuss.libp2p.io/c/users), discuss exciting [research](https://discuss.libp2p.io/c/research), and [stay up to date with important announcements](https://discuss.libp2p.io/c/news).
 
-We also often hang out on [Discord](https://discord.com/invite/ipfs) and in the #libp2p-implementers channel in the [Filecoin slack](https://filecoinproject.slack.com
-). While Discord is a great places for live chats, remember that discussions can get lost in a sea of messages. For long-lived discussion & support, [the discussion forums](https://discuss.libp2p.io) are the way to go.
+We also hang out in the #libp2p-implementers channel in the [Filecoin slack](https://http://filecoin.io/slack).

--- a/content/concepts/discovery-routing/overview.md
+++ b/content/concepts/discovery-routing/overview.md
@@ -40,16 +40,16 @@ implementation, discovery and routing usually happen concurrently.
 libp2p provides a set of modules for different network-level functionality,
 including peer discovery and routing. Peers in libp2p can discover other
 peers using various mechanisms, such as exchanging peer
-[multiaddresses](./../../fundamentals/addressing) over the
+[multiaddresses](/concepts/fundamentals/addressing) over the
 network, querying a directory service, or using a distributed hash table (DHT)
 to store and retrieve information about available peers.
 
 These methods include, but are not limited to:
 
-- [Rendezvous](./../rendezvous): a protocol that allows peers to exchange peer multiaddresses
+- [Rendezvous](/concepts/discovery-routing/rendezvous): a protocol that allows peers to exchange peer multiaddresses
   in a secure and private manner.
-- [mDNS](./../mdns): a multicast Domain Name System (DNS) protocol that allows peers to
+- [mDNS](/concepts/discovery-routing/mdns): a multicast Domain Name System (DNS) protocol that allows peers to
   discover other peers on the local network.
-- [DHT](./../kaddht): Distributed Hash Table, libp2p uses a DHT called Kademlia, it assigns
+- [DHT](/concepts/discovery-routing/kaddht): Distributed Hash Table, libp2p uses a DHT called Kademlia, it assigns
   each piece of content a unique identifier and stores the content on the peer whose
   identifier is closest to the content's identifier.

--- a/content/concepts/discovery-routing/rendezvous.md
+++ b/content/concepts/discovery-routing/rendezvous.md
@@ -73,7 +73,7 @@ The rendezvous protocol runs over libp2p streams using the protocol ID `/rendezv
 
 ### Rendezvous and publish-subscribe
 
-For effective discovery, rendezvous can be combined with [libp2p publish/subscribe](../messaging/pubsub/overview).
+For effective discovery, rendezvous can be combined with [libp2p publish/subscribe](/concepts/pubsub/overview).
 At a basic level, rendezvous can bootstrap pubsub by discovering peers subscribed to a topic. The rendezvous would
 be responsible for publishing packets, subscribing, or unsubscribing from packet shapes.
 

--- a/content/concepts/discovery-routing/rendezvous.md
+++ b/content/concepts/discovery-routing/rendezvous.md
@@ -23,11 +23,11 @@ serve as a hub for nodes to discover.
   solutions like DHT and Gossipsub. DHT (Distributed Hash Table) and Gossipsub are
   decentralized alternatives to Rendezvous.
 
-  [DHT](kaddht.md) is a distributed network protocol used to store and
+  [DHT](/concepts/discovery-routing/kaddht.md) is a distributed network protocol used to store and
   retrieve data in a P2P network efficiently. It is like a hash table mapping keys
   to values, allowing for fast lookups and efficient data distribution across the network.
 
-  [Gossipsub](pubsub.md), on the other hand, is a pub-sub (publish-subscribe) protocol
+  [Gossipsub](/concepts/pubsub/overview.md), on the other hand, is a pub-sub (publish-subscribe) protocol
   that is used to distribute messages and data across a network. It uses a gossip-based
   mechanism to propagate messages throughout the network, allowing fast and efficient
   distribution without relying on a central control point.

--- a/content/concepts/introduction/overview.md
+++ b/content/concepts/introduction/overview.md
@@ -122,7 +122,7 @@ There are several reasons to consider using libp2p as a networking layer to crea
 - **Message Distribution and Dissemination**: One such pattern libp2p uses is
   [publish/subscribe (pubsub)](/concepts/pubsub/overview), which allows a sender (publisher) to send a message
   to multiple recipients (subscribers) without the publisher having to know who the subscribers are.
-  libp2p implements pubsub through the use of protocols like [gossipsub](/concepts/pubsub/gossipsub), providing
+  libp2p implements pubsub through the use of protocols like [gossipsub](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/README.md), providing
   developers with a flexible and efficient means of exchanging data and messages within their P2P
   applications.
 

--- a/content/concepts/introduction/overview.md
+++ b/content/concepts/introduction/overview.md
@@ -106,7 +106,7 @@ There are several reasons to consider using libp2p as a networking layer to crea
 
 - **Resiliency**: P2P networks are often more resilient than traditional client-server networks,
   as there is no single point of failure. libp2p includes features such as
-  [peer discovery](/concepts/discovery/overview) and [content routing](/concepts/routing/overview) that help
+  [peer discovery and content routing](/concepts/discovery-routing/overview/) that help
   to ensure that the network remains available and accessible even if some peers are offline or unreachable.
 
 - **Efficiency**: P2P networks can be more efficient in resource utilization, as data is

--- a/content/concepts/introduction/overview.md
+++ b/content/concepts/introduction/overview.md
@@ -141,7 +141,7 @@ There are several reasons to consider using libp2p as a networking layer to crea
 libp2p remains an integral component in IPFS and can be easily integrated with other projects in the
 IPFS "family". Check their sites for specific information and references:
 
-- [IPFS](https://libp2p.io) is the InterPlanetary File System, which uses libp2p as
+- [IPFS](https://ipfs.tech) is the InterPlanetary File System, which uses libp2p as
   its networking layer.
 - [Multiformats](https://multiformats.io) is a variety of *self-describing* data formats.
 - [IPLD](https://ipld.io) is a set of tools for describing links between content-addressed

--- a/content/concepts/introduction/overview.md
+++ b/content/concepts/introduction/overview.md
@@ -36,7 +36,7 @@ libp2p, (short for "library peer-to-peer")
 is a peer-to-peer (P2P) networking framework that enables the development
 of P2P applications. It consists of a collection of protocols, specifications, and
 libraries that facilitate P2P communication between network participants, known as
-"[peers](/concepts/introduction/fundamentals/peers)."
+"[peers](/concepts/fundamentals/peers)."
 
 ### Peer-to-peer basics
 

--- a/content/concepts/multiplex/early-negotiation.md
+++ b/content/concepts/multiplex/early-negotiation.md
@@ -23,7 +23,7 @@ second
 First, the security protocol is negotiated, then this protocol is used to perform a cryptographic
 handshake. libp2p currently supports [Noise](/concepts/secure-comm/noise) and [TLS 1.3](/concepts/secure-comm/tls).
 Once the cryptographic handshake completes, multistream-select runs again on top of
-the secured connection to negotiate a steam multiplexer, like [yamux](yamux) or [mplex](mplex).
+the secured connection to negotiate a steam multiplexer, like [yamux](/concepts/multiplex/yamux) or [mplex](/concepts/multiplex/mplex).
 
 <!-- ADD DIAGRAM -->
 

--- a/content/concepts/multiplex/mplex.md
+++ b/content/concepts/multiplex/mplex.md
@@ -13,7 +13,7 @@ is now considered critical for a stream multiplexer.
 
 mplex runs over a reliable, ordered pipe between two peers, such as a TCP connection.
 Peers can open, write to, close, and reset a stream. mplex uses a message-based framing
-layer like [yamux](yamux), enabling it to multiplex different
+layer like [yamux](/concepts/multiplex/yamux), enabling it to multiplex different
 data streams, including stream-oriented data and other types of messages.
 
 ### Drawbacks

--- a/content/concepts/nat/dcutr.md
+++ b/content/concepts/nat/dcutr.md
@@ -35,7 +35,7 @@ The DCUtR protocol uses the protocol ID `/libp2p/dcutr` and involves the
 exchange of `Connect` and `Sync` messages.
 
 The DCUtR protocol supports different types of connections, such as TCP and
-[QUIC](../transports/quic.md), the process of establishing a connection is
+[QUIC](/concepts/transports/quic.md), the process of establishing a connection is
 different for each type.
 
 @Dennis-tra has a [great talk](https://www.youtube.com/watch?v=fyhZWlDbcyM) on

--- a/content/concepts/secure-comm/overview.md
+++ b/content/concepts/secure-comm/overview.md
@@ -18,6 +18,6 @@ established.
 
 ## Secure channels in libp2p
 
-libp2p specifies two security protocols, [TLS 1.3](tls) and [Noise](noise).
+libp2p specifies two security protocols, [TLS 1.3](/concepts/secure-comm/tls) and [Noise](/concepts/secure-comm/noise).
 After the handshake has finished, we need to negotiate a
 [stream multiplexer](/concepts/multiplex/overview) for the connection.

--- a/content/concepts/secure-comm/tls.md
+++ b/content/concepts/secure-comm/tls.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 TLS (Transport Layer Security) is one of the security handshakes used to secure transports
-that don't have built-in security (e.g. TCP, WebSocket). [Noise](noise), an alternative to
+that don't have built-in security (e.g. TCP, WebSocket). [Noise](/concepts/secure-comm/noise), an alternative to
 TLS, is also another security handshake used to secure transports.
 
 ## What is TLS?

--- a/content/concepts/security/dos-mitigation.md
+++ b/content/concepts/security/dos-mitigation.md
@@ -115,7 +115,7 @@ Manager](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manag
 limits on the [system
 scope](https://github.com/libp2p/go-libp2p/blob/v0.22.0/p2p/host/resource-manager/limit_defaults.go#L342).
 In rust-libp2p this is done by using
-[`ConnectionLimits`](https://docs.rs/libp2p/latest/libp2p/swarm/struct.ConnectionLimits.html)
+[`ConnectionLimits`](https://docs.rs/libp2p/latest/libp2p/connection_limits/struct.ConnectionLimits.html)
 and passing it to the
 [`SwarmBuilder`](https://docs.rs/libp2p/latest/libp2p/swarm/struct.SwarmBuilder.html#method.connection_limits).
 

--- a/content/concepts/transports/webrtc.md
+++ b/content/concepts/transports/webrtc.md
@@ -42,7 +42,7 @@ The features employed in libp2p are:
   to a peer. This means libp2p can utilize data channels as a transport to send raw data to peers and
   enables applications to build anything they like.
 
-- [NAT traversal](../nat/overview): WebRTC includes mechanisms (like
+- [NAT traversal](/concepts/nat/overview): WebRTC includes mechanisms (like
   [ICE](https://datatracker.ietf.org/doc/rfc5245/)) to connect to nodes that run behind
   NATs and firewalls. In non-decentralized WebRTC, this can be facilitated by a
   [TURN server.](https://webrtc.org/getting-started/turn-server),
@@ -97,7 +97,7 @@ When establishing a WebRTC connection, the browser and server perform a standard
 handshake as part of the connection setup. Of the three primary focuses of information
 security, a successful DTLS handshake only provides two: confidentiality and integrity.
 Authenticity is achieved by succeeding the
-[Noise handshake](../secure-comm/noise) following the DTLS handshake.
+[Noise handshake](/concepts/secure-comm/noise) following the DTLS handshake.
 
 <!-- TO ADD DIAGRAM -->
 


### PR DESCRIPTION
Fixes #309 

I used `lychee --verbose --exclude twitter.com ./public/` to check for dead links to fix. `twitter.com` is excluded because [@libp2p](https://twitter.com/libp2p) is not accessible without logging in.

This expands on #337 , which fixed the dead links in the introduction.