### PR TITLE
Enable link check CI

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,7 +13,8 @@ jobs:
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421 # v1.8.0
         with:
           # Check all markdown in /content/
-          args: --verbose --no-progress './content/'
+          # Exclude twitter.com links because they always 503 unless logged in
+          args: --verbose --no-progress --exclude twitter.com './content/'
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,7 +1,10 @@
 name: links
 
 on:
-  workflow_dispatch:
+  push:
+    branches: master
+  pull_request:
+    branches: master
 
 jobs:
   linkChecker:

--- a/content/concepts/contribute/community.md
+++ b/content/concepts/contribute/community.md
@@ -11,4 +11,4 @@ We love talking about libp2p, and we'd be happy to have you in the mix.
 
 Visit our [discussion forums](https://discuss.libp2p.io) to ask questions about [using libp2p](https://discuss.libp2p.io/c/users), discuss exciting [research](https://discuss.libp2p.io/c/research), and [stay up to date with important announcements](https://discuss.libp2p.io/c/news).
 
-We also hang out in the #libp2p-implementers channel in the [Filecoin slack](https://http://filecoin.io/slack).
+We also hang out in the #libp2p-implementers channel in the [Filecoin slack](https://filecoin.io/slack).


### PR DESCRIPTION
* Exclude twitter links from CI check
* Enable link check worklow on any push/merge to master
* Fix typo in filecoin slack link

~~I don't have permission to dispatch the worklow so I guess this will be tested when it's merged to master :crossed_fingers:~~
Never mind, looks like it's run on attempted merges to master :+1: 