### PR TITLE
fix: broken link for launchpad DHT docs

### DIFF
--- a/content/concepts/fundamentals/dht.md
+++ b/content/concepts/fundamentals/dht.md
@@ -4,4 +4,4 @@ description: Flexible networks need flexible addressing systems. Since libp2p is
 weight: 40
 ---
 
-Check out the following Launchpad guide on the [DHT](https://curriculum.pl-launchpad.io/curriculum/libp2p/dht/).
+Check out the following Launchpad guide on the [DHT](https://pl-launchpad.io/curriculum/libp2p/dht/).


### PR DESCRIPTION
Current link (https://curriculum.pl-launchpad.io/curriculum/libp2p/dht/) returns error `500`