### PR TITLE
Updated nim-libp2p documentation url

### DIFF
--- a/content/guides/getting-started/nim.md
+++ b/content/guides/getting-started/nim.md
@@ -7,4 +7,4 @@ aliases:
     - "/guides/nim"
 ---
 
-Check out [tutorials of the Nim libp2p implementation](https://status-im.github.io/nim-libp2p/docs/).
+Check out [tutorials of the Nim libp2p implementation](https://vacp2p.github.io/nim-libp2p/docs/).


### PR DESCRIPTION
- The nim-libp2p documentation URL link is not working
- The updated documentation link is: https://vacp2p.github.io/nim-libp2p/docs/