### PR TITLE
Fix broken examples link in javascript.md

### DIFF
--- a/content/guides/getting-started/javascript.md
+++ b/content/guides/getting-started/javascript.md
@@ -273,7 +273,7 @@ Success! Our two peers are now communicating over a multiplexed, secure channel.
 
 After finishing this tutorial, you should have a look into the [js-libp2p getting started](https://github.com/libp2p/js-libp2p/blob/master/doc/GETTING_STARTED.md) document, which goes from a base configuration like this one, to more custom ones.
 
-You also have a panoply of examples on [js-libp2p repo](https://github.com/libp2p/js-libp2p/tree/master/examples) that you can leverage to learn how to use `js-libp2p` for several different use cases and runtimes.
+You also have a panoply of [examples](https://github.com/libp2p/js-libp2p-examples/tree/main/examples) that you can leverage to learn how to use `js-libp2p` for several different use cases and runtimes.
 
 [definition_multiaddress]: /reference/glossary/#multiaddr
 [definition_multiplexer]: /reference/glossary/#multiplexer


### PR DESCRIPTION
The current link gives a 404, so I changed it to what I think is the new examples location. As someone new (returning) to libp2p, this is an important link, as it is a natural next step but not easily discovered. 

I also changed the wording slightly since it was an ill-formed sentence and indicated that the source is a part of the main libp2p repo, which is not the case any more.